### PR TITLE
fix(server): serve SPA shell for client routes containing dots

### DIFF
--- a/crates/rhizz-server/src/server.rs
+++ b/crates/rhizz-server/src/server.rs
@@ -85,8 +85,12 @@ async fn spa_fallback(uri: Uri) -> Response {
     serve_path(path)
 }
 
-/// Serves `path` from the embedded assets. Missing paths that look like
-/// real files (contain a `.`) 404; anything else gets the SPA shell.
+/// Serves `path` from the embedded assets. Any path that isn't a real
+/// embedded file gets the SPA shell — the client router decides whether a
+/// route is valid and renders its own 404. We deliberately don't try to
+/// guess which paths are "real" routes: client-side routes can contain
+/// dots in path segments (e.g. `/diagrams/embed/main.hcl`), so a
+/// "contains a dot ⇒ 404" heuristic would break them.
 fn serve_path(path: &str) -> Response {
     let relative = path.trim_start_matches('/');
     if relative.is_empty() {
@@ -94,9 +98,6 @@ fn serve_path(path: &str) -> Response {
     }
     if let Some(file) = StaticAssets::get(relative) {
         return asset_response(file, relative);
-    }
-    if relative.contains('.') {
-        return error_response(StatusCode::NOT_FOUND, "not found");
     }
     spa_shell()
 }
@@ -224,6 +225,25 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/projects/staging/diagrams")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_content_type(&response, "text/html");
+    }
+
+    #[tokio::test]
+    async fn client_route_with_dot_in_segment_falls_back_to_spa_shell() {
+        // A client-side route whose path contains a dot in a segment (here
+        // the `main.hcl` file name) must still get the SPA shell — it is not
+        // a missing static asset.
+        let tmp = tempfile::tempdir().unwrap();
+        let response = app_at(&tmp)
+            .oneshot(
+                Request::builder()
+                    .uri("/projects/04e58d81-8bc3-4cc6-9a04-b9da48b996bb/diagrams/embed/main.hcl")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/web/src/routes/projects/[id]/explore/Explore.stories.ts
+++ b/web/src/routes/projects/[id]/explore/Explore.stories.ts
@@ -427,6 +427,42 @@ export const BreadcrumbNavigation: Story = {
   },
 };
 
+export const EmbedDiagramButton: Story = {
+  args: {
+    projectId: seededProject.id,
+  },
+  loaders: [
+    async () => {
+      await init();
+      const fs = openProjectFs(projectStore, seededProject.id);
+      for (const [name, layout] of Object.entries(EXAMPLE_SYSTEM_DIAGRAMS)) {
+        await writeDiagramLayoutFile(
+          fs,
+          `${DIAGRAM_LAYOUT_DIR}/${name}`,
+          layout,
+        );
+      }
+      return {};
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The embed button sits in the top bar of the Explore view.
+    const button = await canvas.findByRole("button", {
+      name: /embed diagram/i,
+    });
+    await expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    // The modal opens with the direct embed URL and iframe snippet.
+    await expect(
+      await canvas.findByText("Direct Embed URL"),
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByText("HTML <iframe> Embed Code"),
+    ).toBeInTheDocument();
+  },
+};
+
 export const Apollo11: Story = {
   parameters: {
     viewport: { defaultViewport: "responsive" },

--- a/web/src/routes/projects/[id]/explore/Explore.svelte
+++ b/web/src/routes/projects/[id]/explore/Explore.svelte
@@ -404,10 +404,12 @@ let boxes = $derived.by<Record<number, DiagramStaticBox>>(() => {
             <li><span class="text-base-content/60">Explore</span></li>
             <li><span>{diagramTitle(selectedDiagramPath)}</span></li>
           </ul>
-          <EmbedDiagramButton
-            projectId={effectiveProjectId}
-            diagramPath={selectedDiagramPath}
-          />
+          <div class="shrink-0 w-40">
+            <EmbedDiagramButton
+              projectId={effectiveProjectId}
+              diagramPath={selectedDiagramPath}
+            />
+          </div>
         </nav>
       {/if}
       <div

--- a/web/src/routes/projects/[id]/explore/Explore.svelte
+++ b/web/src/routes/projects/[id]/explore/Explore.svelte
@@ -14,6 +14,7 @@ import { readProjectSources, type Source } from "../../../../vfs/compile";
 import { type Dirent, openProjectFs } from "../../../../vfs/fs";
 import FileTree from "../editor/FileTree.svelte";
 import DiagramStaticView from "../diagrams/DiagramStaticView.svelte";
+import EmbedDiagramButton from "../diagrams/EmbedDiagramButton.svelte";
 import type { DiagramStaticBox } from "../diagrams/types";
 import {
   DIAGRAM_LAYOUT_DIR,
@@ -396,13 +397,17 @@ let boxes = $derived.by<Record<number, DiagramStaticBox>>(() => {
     <div class="flex flex-col flex-1 min-w-0 min-h-0 h-full">
       {#if selectedDiagramPath}
         <nav
-          class="breadcrumbs px-4 py-2 text-sm border-b border-base-300 bg-base-100"
+          class="flex items-center justify-between px-4 py-2 text-sm border-b border-base-300 bg-base-100"
           aria-label="Diagram breadcrumb"
         >
-          <ul>
+          <ul class="breadcrumbs">
             <li><span class="text-base-content/60">Explore</span></li>
             <li><span>{diagramTitle(selectedDiagramPath)}</span></li>
           </ul>
+          <EmbedDiagramButton
+            projectId={effectiveProjectId}
+            diagramPath={selectedDiagramPath}
+          />
         </nav>
       {/if}
       <div


### PR DESCRIPTION
The serve_path fallback 404'd any missing path containing a '.', on the assumption it was a missing static asset. But client-side routes can legitimately contain dots in path segments (e.g.
/projects/<id>/diagrams/embed/main.hcl), so those valid routes 404'd. Remove the heuristic and always fall back to the SPA shell for non-/api/ paths, letting the client router handle 404s. Add a regression test.