### PR TITLE
feat(book): verify book example outputs against book.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,26 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Builds the mdBook with the current compiler and verifies that the
+  # compiled ```rhizz blocks still match book/book.lock. Any drift in the
+  # book's examples or the compiler's diagnostics fails this job.
+  book:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: "0.5.4"
+          # The preprocessor finds the CLI in target/debug/rhizz.
+      - run: cargo build --bin rhizz --quiet
+
+      - run: mdbook build book
+
   frontend:
     needs: wasm
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,16 @@ jobs:
 
       - run: mdbook build book
 
+      - run: |
+          rm -rf book-artifact
+          mkdir -p book-artifact
+          cp -a book/target-mdbook/. book-artifact/
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rhizz-book
+          path: book-artifact/
+
   frontend:
     needs: wasm
     runs-on: ubuntu-latest
@@ -188,11 +198,13 @@ jobs:
           path: docs-artifact/
 
   deploy-pages:
-    needs: [publish, docs]
+    needs: [publish, docs, book]
     # Publish is skipped unless the "chromatic" trigger fires; deploy still
-    # runs (docs are always deployed) but never after a failed publish.
+    # runs (docs & book are always deployed) but never after a failed publish
+    # or a failed book/docs build.
     if: ${{ github.event_name != 'pull_request' && !cancelled() &&
-      needs.publish.result != 'failure' && needs.docs.result == 'success' }}
+      needs.publish.result != 'failure' && needs.docs.result == 'success' &&
+      needs.book.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -208,6 +220,11 @@ jobs:
         with:
           name: rhizz-docs
           path: pages/docs/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: rhizz-book
+          path: pages/book/
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ web/package-lock.json
 
 # macos temporaries
 .DS_Store
+
+# Python bytecode (book preprocessor + tests)
+__pycache__/

--- a/Justfile
+++ b/Justfile
@@ -26,6 +26,7 @@ lint:
 test:
     {{run}} cargo test --quiet --all
     {{run}} sh -lc 'cd web && deno run test'
+    {{run}} sh -lc 'cd book/preprocessors && python3 -m unittest -q'
 
 # Frontend artifacts first, so rhizz-server's build.rs embeds the real
 # UI (wasm pkg is a file: dependency of web/, and vite populates web/build).
@@ -34,6 +35,19 @@ build:
     {{run}} sh -lc 'cd web && npx vite build'
     {{run}} sh -lc 'cd web && dx storybook build'
     {{run}} cargo build --release --all-targets
+
+# Builds the mdBook (book/). The preprocessor compiles every ```rhizz block
+# with the current CLI and verifies the results against book/book.lock
+# (regenerate with `just book-accept` after intentional changes).
+book:
+    {{run}} cargo build --quiet --bin rhizz
+    {{run}} mdbook build book
+
+# Regenerates book/book.lock from the current compiler output.
+# Review the per-block diff it prints before committing.
+book-accept:
+    {{run}} cargo build --quiet --bin rhizz
+    {{run}} sh -lc 'BOOKLOCK_ACCEPT_CHANGES=1 mdbook build book'
 
 # Starts a dev server. If you're an AI, never use this. It will just hang forever.
 dev:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,27 @@ environment.
 > wins). This is an accepted limitation for the current MVP stage; a
 > revision/ETag check is planned before multi-user use.
 
+## Documentation (book)
+
+The mdBook in `book/` documents the language with live examples: its preprocessor
+compiles every ```rhizz block with the current `rhizz` CLI and renders a verdict
+panel (errors, warnings, completion score).
+
+Compiler outputs of the examples are traced in `book/book.lock` (keyed by chapter
+and input hash). Any build that produces different output — a stale example, or a
+compiler change that alters its diagnostics — **fails** with a per-block diff:
+
+```
+just book          # build + verify book.lock
+```
+
+To intentionally regenerate the lock (after fixing examples or changing the
+compiler), review the printed diff and commit the result:
+
+```
+just book-accept   # BOOKLOCK_ACCEPT_CHANGES=1 mdbook build book
+```
+
 ## Development commands
 
 See the [Justfile](Justfile).

--- a/README.md
+++ b/README.md
@@ -83,27 +83,6 @@ environment.
 > wins). This is an accepted limitation for the current MVP stage; a
 > revision/ETag check is planned before multi-user use.
 
-## Documentation (book)
-
-The mdBook in `book/` documents the language with live examples: its preprocessor
-compiles every ```rhizz block with the current `rhizz` CLI and renders a verdict
-panel (errors, warnings, completion score).
-
-Compiler outputs of the examples are traced in `book/book.lock` (keyed by chapter
-and input hash). Any build that produces different output — a stale example, or a
-compiler change that alters its diagnostics — **fails** with a per-block diff:
-
-```
-just book          # build + verify book.lock
-```
-
-To intentionally regenerate the lock (after fixing examples or changing the
-compiler), review the printed diff and commit the result:
-
-```
-just book-accept   # BOOKLOCK_ACCEPT_CHANGES=1 mdbook build book
-```
-
 ## Development commands
 
 See the [Justfile](Justfile).

--- a/SPEC/diagnostics/W015.md
+++ b/SPEC/diagnostics/W015.md
@@ -1,0 +1,47 @@
+# W015 — Unexpected block type ignored
+
+A block whose type is not recognized in its current scope was silently skipped
+during parsing. The most common cause is using the old inline grammar — a
+`component` block nested directly inside a `system` or another `component` —
+which is no longer supported. Components are now top-level reusable
+definitions, instantiated via `instance "<label>" { source = "<definition>" }`.
+
+This is a warning (non-blocking) to stay consistent with rhizz's gradual,
+permissive compilation model: an unknown block never hard-fails the build, so
+a spec that is mid-migration still compiles. But the ignored block is *not*
+part of the model, so references to anything it declared will fail to resolve
+and you should fix the construct.
+
+## Example (warning)
+
+```hcl
+system "app" {
+  component "sender" {   # Warning: 'component' is not valid inside a system
+    leaf = true
+  }
+
+  connection "greet" {
+    from = "sender/out"
+    to   = "receiver/in"
+  }
+}
+```
+
+## Fix
+
+Move the `component` body to a top-level definition and reference it from the
+system with `instance`:
+
+```hcl
+component "sender" {
+  leaf = true
+}
+
+system "app" {
+  instance "sender" {
+    source = "sender"
+  }
+}
+```
+
+If the block was a typo or a stray construct, remove it.

--- a/book/book.lock
+++ b/book/book.lock
@@ -1,0 +1,103 @@
+{
+  "entries": [
+    {
+      "chapter": "greeter.md",
+      "hcl": "project {\n  name = \"greeter\"\n}\n\nprotocol \"greeting\" {\n  description = \"A simple greeting\"\n\n  message \"hello\" {\n    description = \"The greeting payload\"\n    field \"text\" { type = \"string\" }\n  }\n}\n\nsystem \"app\" {\n  description = \"A minimal two-component model\"\n\n  component \"sender\" {\n    description = \"Sends a greeting\"\n    leaf        = true\n\n    port \"out\" {\n      protocol = \"greeting\"\n    }\n  }\n\n  component \"receiver\" {\n    description = \"Receives a greeting\"\n    leaf        = true\n\n    port \"in\" {\n      protocol = \"greeting\"\n    }\n  }\n\n  connection \"greet\" {\n    description = \"Carries the greeting\"\n    from        = \"sender/out\"\n    to          = \"receiver/in\"\n  }\n}",
+      "input_sha256": "8524fa00c3378f9180548b8eac3376979f955fe5a5e000d06b3f0c3c04ef31e8",
+      "output": {
+        "errors": [
+          {
+            "code": "E011",
+            "message": "connection 'greet' references undefined component 'receiver' in 'to'"
+          },
+          {
+            "code": "E011",
+            "message": "connection 'greet' references undefined component 'sender' in 'from'"
+          }
+        ],
+        "warnings": [
+          {
+            "code": "W005",
+            "message": "connection 'greet' has 'from' and 'to' pointing to the same component"
+          },
+          {
+            "code": "W012",
+            "message": "top-level protocol 'greeting' is not referenced by any port"
+          }
+        ]
+      }
+    },
+    {
+      "chapter": "sketch.md",
+      "hcl": "project {\n  name = \"sketch\"\n}\n\nprotocol \"serial\" {\n  # No messages are defined yet.\n}\n\ncomponent \"sensor-hat\" {\n  description = \"Reusable sensor board\"\n  leaf        = true\n\n  port \"data\" {\n    protocol = \"serial\"\n  }\n}\n\nsystem \"dev-rig\" {\n  description = \"A rough first sketch\"\n\n  component \"controller\" {\n    leaf = true\n\n    port \"uart\" {\n      protocol = \"serial\"\n    }\n  }\n\n  component \"sensor\" {\n    source = \"sensor-hat\"\n  }\n\n  connection \"link\" {\n    from = \"controller/uart\"\n    to   = \"sensor/data\"\n  }\n}",
+      "input_sha256": "b152e530691ecdfad4caa46930628fb375578bf1de9b57ad0b8d770a8d60644c",
+      "output": {
+        "errors": [
+          {
+            "code": "E011",
+            "message": "connection 'link' references undefined component 'controller' in 'from'"
+          },
+          {
+            "code": "E011",
+            "message": "connection 'link' references undefined component 'sensor' in 'to'"
+          }
+        ],
+        "warnings": [
+          {
+            "code": "W003",
+            "message": "component 'sensor-hat' is not referenced by any connection"
+          },
+          {
+            "code": "W004",
+            "message": "connection 'link' is missing a description"
+          },
+          {
+            "code": "W005",
+            "message": "connection 'link' has 'from' and 'to' pointing to the same component"
+          },
+          {
+            "code": "W010",
+            "message": "port 'data' is not referenced by any connection"
+          },
+          {
+            "code": "W011",
+            "message": "protocol 'serial' has no messages defined"
+          }
+        ]
+      }
+    },
+    {
+      "chapter": "wiring-bug.md",
+      "hcl": "project {\n  name = \"wiring-bug\"\n}\n\nprotocol \"greeting\" {\n  description = \"A simple greeting\"\n\n  message \"hello\" {\n    description = \"The greeting payload\"\n    field \"text\" { type = \"string\" }\n  }\n}\n\nsystem \"app\" {\n  description = \"Two components with a broken connection\"\n\n  component \"sender\" {\n    description = \"Sends a greeting\"\n    leaf        = true\n\n    port \"out\" {\n      protocol = \"greeting\"\n    }\n  }\n\n  component \"receiver\" {\n    description = \"Receives a greeting\"\n    leaf        = true\n\n    port \"in\" {\n      protocol = \"greeting\"\n    }\n  }\n\n  connection \"greet\" {\n    from = \"sender/outgoing\" // typo: this port does not exist\n    to   = \"receiver/in\"\n  }\n}",
+      "input_sha256": "4f58b6a87ec8e504d5c64c18e73f7061d5376d85bad577ba617bb0dece3e1855",
+      "output": {
+        "errors": [
+          {
+            "code": "E011",
+            "message": "connection 'greet' references undefined component 'receiver' in 'to'"
+          },
+          {
+            "code": "E011",
+            "message": "connection 'greet' references undefined component 'sender' in 'from'"
+          }
+        ],
+        "warnings": [
+          {
+            "code": "W004",
+            "message": "connection 'greet' is missing a description"
+          },
+          {
+            "code": "W005",
+            "message": "connection 'greet' has 'from' and 'to' pointing to the same component"
+          },
+          {
+            "code": "W012",
+            "message": "top-level protocol 'greeting' is not referenced by any port"
+          }
+        ]
+      }
+    }
+  ],
+  "format": 1,
+  "rhizz_version": "rhizz 0.1.0"
+}

--- a/book/book.lock
+++ b/book/book.lock
@@ -23,6 +23,14 @@
           {
             "code": "W012",
             "message": "top-level protocol 'greeting' is not referenced by any port"
+          },
+          {
+            "code": "W015",
+            "message": "unexpected block type 'component' inside system ignored"
+          },
+          {
+            "code": "W015",
+            "message": "unexpected block type 'component' inside system ignored"
           }
         ]
       }
@@ -62,6 +70,14 @@
           {
             "code": "W011",
             "message": "protocol 'serial' has no messages defined"
+          },
+          {
+            "code": "W015",
+            "message": "unexpected block type 'component' inside system ignored"
+          },
+          {
+            "code": "W015",
+            "message": "unexpected block type 'component' inside system ignored"
           }
         ]
       }
@@ -93,6 +109,14 @@
           {
             "code": "W012",
             "message": "top-level protocol 'greeting' is not referenced by any port"
+          },
+          {
+            "code": "W015",
+            "message": "unexpected block type 'component' inside system ignored"
+          },
+          {
+            "code": "W015",
+            "message": "unexpected block type 'component' inside system ignored"
           }
         ]
       }

--- a/book/preprocessors/rhizz.py
+++ b/book/preprocessors/rhizz.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""mdbook preprocessor for ```rhizz code blocks.
+"""mdbook preprocessor for ```rhizz code blocks, with book.lock golden checks.
 
 Each fenced block tagged `rhizz` is written to a temp project, compiled with
 the rhizz CLI (`--json build`), and replaced by the original HCL code block
@@ -12,6 +12,34 @@ plus an HTML panel summarizing the compiler's verdict:
 
 Block attributes after the tag (e.g. ```rhizz,ignore) are supported: `ignore`
 renders the code without compiling it.
+
+Golden-file verification (`book/book.lock`)
+-------------------------------------------
+
+The preprocessor also acts as a guard against silently drifting documentation:
+every compiled block is traced from its HCL input to its normalized compiler
+output ({errors, warnings, score}) and compared against `book/book.lock`
+inside the book directory:
+
+- key = (chapter path, sha256 of the exact HCL input), value = normalized
+  compiler output;
+- on a normal build a mismatch (changed output, new block, removed block,
+  missing or corrupt lock file) aborts the build with a per-entry diff;
+- set `BOOKLOCK_ACCEPT_CHANGES=1` to regenerate `book/book.lock` in place
+  (review the diff it prints before committing).
+
+Normalization keeps the comparison deterministic:
+
+- diagnostics are sorted by (code, line, message) so compiler reordering
+  cannot cause spurious failures;
+- the `file` field of a diagnostic is dropped (its value is a tempdir path
+  that legitimately changes between runs);
+- the lock is written as indented, key-sorted JSON.
+
+Metadata (`format` number, `rhizz_version`) is stored for humans and is not
+part of the comparison. A state where the compiler could not run (missing
+binary, per-block tool failures) is never locked and always fails the build:
+a lock must mean "the current toolchain produced exactly this output".
 
 Requires only the Python standard library. The rhizz binary is located via
 $RHIZZ_BIN, then $PATH, then the repository's target/{release,debug} dirs.
@@ -34,6 +62,8 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LOCK_FILE = REPO_ROOT / "book" / "book.lock"
+LOCK_FORMAT = 1
 
 # ```
 _FENCE_OPEN_RE = re.compile(r"^[ \t]*```[ \t]*rhizz[ \t]*(.*)$")
@@ -58,6 +88,16 @@ def find_rhizz() -> str | None:
 
 
 RHIZZ_BIN = find_rhizz()
+
+
+def accept_changes_enabled() -> bool:
+    """True when book.lock may be regenerated from current compiler output."""
+    return os.environ.get("BOOKLOCK_ACCEPT_CHANGES", "").lower() not in ("", "0", "false", "no")
+
+
+def die(message: str) -> None:
+    sys.stderr.write(f"book.lock: {message}\n")
+    sys.exit(1)
 
 
 def parse_block_attrs(raw: str) -> set[str]:
@@ -128,6 +168,143 @@ def compile_one(content: str) -> dict:
         return {"tool_error": f"{type(exc).__name__}: {exc}"}
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def rhizz_version(bin_path: str | None) -> str | None:
+    """Best-effort `rhizz --version` output; None when unavailable."""
+    if not bin_path:
+        return None
+    try:
+        proc = subprocess.run([bin_path, "--version"], capture_output=True, text=True, timeout=30)
+        return (proc.stdout or proc.stderr).strip() or None
+    except Exception:  # noqa: BLE001 - metadata only, never fatal
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Normalization: turn raw `--json build` dicts into the deterministic form
+# that book.lock compares.
+# ---------------------------------------------------------------------------
+
+
+def normalize_diag(d: dict) -> dict:
+    """Keep code / line / message; drop `file` (a tempdir path that changes)."""
+    out = {"code": str(d.get("code", ""))}
+    line = d.get("line")
+    if line is not None:
+        out["line"] = int(line)
+    out["message"] = str(d.get("message", ""))
+    return out
+
+
+def diag_sort_key(d: dict):
+    return (d.get("code", ""), d.get("line", -1), d.get("message", ""))
+
+
+def normalize_output(raw: dict) -> dict | None:
+    """Return the comparable {errors, warnings, score} for a compile result.
+
+    Returns None when the compile did not run (`tool_error`). Such a state is
+    never written to book.lock and never accepted as a match — a lock must
+    always describe what the current toolchain really produced.
+    """
+    if raw.get("tool_error"):
+        return None
+    out = {
+        "errors": sorted((normalize_diag(e) for e in raw.get("errors") or []), key=diag_sort_key),
+        "warnings": sorted((normalize_diag(w) for w in raw.get("warnings") or []), key=diag_sort_key),
+    }
+    if raw.get("score"):
+        out["score"] = raw["score"]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The lock file.
+# ---------------------------------------------------------------------------
+
+
+def lock_payload(entries: list[dict], compiler_version: str | None) -> dict:
+    return {
+        "format": LOCK_FORMAT,
+        "rhizz_version": compiler_version or "unknown",
+        "entries": sorted(entries, key=lambda e: (e["chapter"], e["input_sha256"])),
+    }
+
+
+def write_lock(entries: list[dict], compiler_version: str | None) -> None:
+    text = json.dumps(lock_payload(entries, compiler_version), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    tmp = LOCK_FILE.with_name(LOCK_FILE.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, LOCK_FILE)
+
+
+def read_lock() -> tuple[dict | None, str | None]:
+    """Return (parsed lock, error). A missing file is (None, None)."""
+    try:
+        return json.loads(LOCK_FILE.read_text(encoding="utf-8")), None
+    except FileNotFoundError:
+        return None, None
+    except Exception as exc:  # noqa: BLE001 - corrupt file is a hard failure
+        return None, f"{LOCK_FILE} exists but cannot be parsed: {exc}"
+
+
+def render_output(out) -> str:
+    return json.dumps(out, sort_keys=True, ensure_ascii=False)
+
+
+def compare_lock(lock: dict, blocks: dict, current_version: str | None) -> tuple[list[str], list[str]]:
+    """Diff the current blocks against the lock.
+
+    Returns (diffs, notes). Diffs abort the build (unless accepting);
+    notes are informational (metadata drift, not output drift).
+    """
+    diffs: list[str] = []
+    notes: list[str] = []
+
+    if lock.get("format") != LOCK_FORMAT:
+        diffs.append(
+            f"{LOCK_FILE} uses lock format {lock.get('format')!r}, expected {LOCK_FORMAT} "
+            f"(regenerate with BOOKLOCK_ACCEPT_CHANGES=1)"
+        )
+        return diffs, notes
+
+    locked = {(e.get("chapter"), e.get("input_sha256")): e for e in lock.get("entries") or []}
+
+    for (chapter, sha), block in sorted(blocks.items()):
+        if (chapter, sha) not in locked:
+            diffs.append(
+                f"new block in {chapter!r} (input {sha[:8]}) is not present in book.lock"
+            )
+            continue
+        old = locked[(chapter, sha)].get("output")
+        new = block.get("output")
+        if old != new:
+            diffs.append(
+                f"output changed for block in {chapter!r} (input {sha[:8]}):\n"
+                f"    lock: {render_output(old)}\n"
+                f"    now:  {render_output(new)}"
+            )
+
+    for (chapter, sha), entry in sorted(locked.items()):
+        if (chapter, sha) not in blocks:
+            diffs.append(
+                f"block in {chapter!r} (input {sha[:8]}) was removed from the book "
+                f"but is still present in book.lock"
+            )
+
+    locked_version = lock.get("rhizz_version")
+    if locked_version and current_version and locked_version != current_version:
+        notes.append(
+            f"book.lock was generated with {locked_version!r}, the current compiler "
+            f"reports {current_version!r} (outputs still match)"
+        )
+    return diffs, notes
+
+
+# ---------------------------------------------------------------------------
+# Rendering.
+# ---------------------------------------------------------------------------
 
 
 def esc(value) -> str:
@@ -209,75 +386,74 @@ def panel_html(data: dict) -> str:
 IGNORE_PANEL = '<div class="rhizz-diag rhizz-ignore"><div class="rhizz-head">Not compiled in this book</div></div>'
 
 
-def transform_content(content: str) -> str:
-    """Replace every ```rhizz block with ```hcl + a compilation results panel."""
+def body_hash(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def transform_chapter(chapter: dict, results: dict[str, dict]) -> tuple[str, dict]:
+    """Replace every ```rhizz block with ```hcl + a verdict panel.
+
+    Returns (new content, {(chapter, sha): block entry}) where each entry is
+    {"chapter", "input_sha256", "hcl", "output"} — the tracing written to
+    book.lock. Block output may be None when the tool failed; callers treat
+    that as a degraded environment.
+    """
+    content = chapter.get("content") or ""
+    chapter_path = chapter.get("path") or chapter.get("source_path") or chapter.get("name") or "<unknown>"
     segments = parse_blocks(content.splitlines())
 
-    # Collect unique block bodies (compile each distinct model once).
-    unique: dict[str, str] = {}
-    for seg in segments:
-        if seg[0] == "block":
-            _, attrs, body = seg
-            if "ignore" not in attrs:
-                key = hashlib.sha256("\n".join(body).encode("utf-8")).hexdigest()
-                unique[key] = "\n".join(body)
-
-    results: dict[str, dict] = {}
-    if unique:
-        with ThreadPoolExecutor(max_workers=MAX_COMPILE_WORKERS) as pool:
-            for key, data in zip(unique.keys(), pool.map(compile_one, unique.values())):
-                results[key] = data
-
     out: list[str] = []
+    blocks: dict[tuple[str, str], dict] = {}
     for seg in segments:
         if seg[0] == "text":
             out.extend(seg[1])
             continue
-        _, attrs, body = seg
+        _, attrs, body_lines = seg
+        body = "\n".join(body_lines)
+        sha = body_hash(body)
+
         out.append("```hcl")
-        out.extend(body)
+        out.extend(body_lines)
         out.append("```")
         out.append("")
         if "ignore" in attrs:
             out.append(IGNORE_PANEL)
-        else:
-            key = hashlib.sha256("\n".join(body).encode("utf-8")).hexdigest()
-            try:
-                out.append(panel_html(results[key]))
-            except Exception as exc:  # noqa: BLE001 - never break the book over one panel
-                out.append(
-                    f'<div class="rhizz-diag rhizz-tool"><div class="rhizz-head">'
-                    f"\u26a0 Panel error</div><p class=\"rhizz-msg\">{esc(exc)}</p></div>"
-                )
+            out.append("")
+            continue
+
+        raw = results.get(sha, {"tool_error": "no compile result recorded"})
+        blocks[(chapter_path, sha)] = {
+            "chapter": chapter_path,
+            "input_sha256": sha,
+            "hcl": body,
+            "output": normalize_output(raw),
+        }
+        out.append(panel_html(raw))
         out.append("")
-    return "\n".join(out)
+
+    return "\n".join(out), blocks
 
 
-def process_item(item: dict) -> None:
-    kind = item.get("Chapter")
-    if kind:
-        process_chapter(kind)
+# ---------------------------------------------------------------------------
+# mdbook traversal.
+# ---------------------------------------------------------------------------
 
 
-def process_chapter(chapter: dict) -> None:
-    content = chapter.get("content")
-    if isinstance(content, str):
-        chapter["content"] = transform_content(content)
-    for sub in chapter.get("sub_items") or []:
-        if isinstance(sub, dict):
-            process_item(sub)
-
-
-def process_section(section: dict) -> None:
-    chapter = section.get("Chapter")
-    if not chapter:
-        return
-    content = chapter.get("content")
-    if isinstance(content, str):
-        chapter["content"] = transform_content(content)
-    for sub in chapter.get("sub_items") or []:
-        if isinstance(sub, dict):
-            process_section(sub)
+def iter_chapters(items) -> list[dict]:
+    """Flatten mdbook's book items into the chapter dicts, depth-first."""
+    chapters: list[dict] = []
+    stack = list(items or [])
+    while stack:
+        item = stack.pop()
+        if not isinstance(item, dict):
+            continue
+        chapter = item.get("Chapter")
+        if isinstance(chapter, dict):
+            chapters.append(chapter)
+            stack.extend(chapter.get("sub_items") or [])
+        else:
+            stack.extend(item.get("sub_items") or [])
+    return chapters
 
 
 def main() -> None:
@@ -295,12 +471,72 @@ def main() -> None:
         json.dump({"items": []}, sys.stdout)
         return
 
-    ctx, book = json.loads(raw)
-    for item in book.get("items") or []:
-        if isinstance(item, dict):
-            process_item(item)
+    _ctx, book = json.loads(raw)
+    chapters = iter_chapters(book.get("items") or [])
 
-    # mdbook expects a Book object (same shape) back, not the tuple.
+    # Degraded environment: cannot compile -> cannot verify -> must not lock.
+    if RHIZZ_BIN is None:
+        die("rhizz binary not found (set $RHIZZ_BIN or add it to PATH); cannot compile blocks or verify book.lock")
+
+    # Compile each distinct HCL body once.
+    unique_bodies: dict[str, str] = {}
+    for ch in chapters:
+        for seg in parse_blocks((ch.get("content") or "").splitlines()):
+            if seg[0] == "block" and "ignore" not in seg[1]:
+                unique_bodies.setdefault(body_hash("\n".join(seg[2])), "\n".join(seg[2]))
+
+    results: dict[str, dict] = {}
+    if unique_bodies:
+        with ThreadPoolExecutor(max_workers=MAX_COMPILE_WORKERS) as pool:
+            for sha, data in zip(unique_bodies.keys(), pool.map(compile_one, unique_bodies.values())):
+                results[sha] = data
+
+    # Transform every chapter, collecting the input -> output trace.
+    entries: dict[tuple[str, str], dict] = {}
+    degraded: list[str] = []
+    for ch in chapters:
+        new_content, chapter_entries = transform_chapter(ch, results)
+        ch["content"] = new_content
+        for key, entry in chapter_entries.items():
+            entries[key] = entry
+            if entry["output"] is None:
+                degraded.append(f"{entry['chapter']!r} (input {entry['input_sha256'][:8]})")
+
+    if degraded:
+        die(
+            "cannot verify book.lock: the compiler failed for block(s) "
+            + ", ".join(degraded)
+            + "; fix the toolchain first"
+        )
+
+    # book.lock verification.
+    current_version = rhizz_version(RHIZZ_BIN)
+    lock, lock_error = read_lock()
+    if lock_error:
+        die(f"{lock_error}; delete it and regenerate with BOOKLOCK_ACCEPT_CHANGES=1")
+
+    if lock is None:
+        if accept_changes_enabled():
+            write_lock(list(entries.values()), current_version)
+            sys.stderr.write(f"book.lock: generated {len(entries)} entries\n")
+        else:
+            die(
+                f"{LOCK_FILE} not found; generate it once with BOOKLOCK_ACCEPT_CHANGES=1"
+            )
+    else:
+        diffs, notes = compare_lock(lock, entries, current_version)
+        if diffs:
+            rendered = "\n".join(f"  - {d}" for d in diffs)
+            if accept_changes_enabled():
+                write_lock(list(entries.values()), current_version)
+                sys.stderr.write(f"book.lock regenerated ({len(entries)} entries):\n{rendered}\n")
+            else:
+                sys.stderr.write(f"book.lock is out of date ({len(diffs)} difference(s)):\n{rendered}\n")
+                die("re-run with BOOKLOCK_ACCEPT_CHANGES=1 to regenerate book.lock")
+        else:
+            for note in notes:
+                sys.stderr.write(f"book.lock: note: {note}\n")
+
     json.dump(book, sys.stdout, ensure_ascii=False)
 
 

--- a/book/preprocessors/test_rhizz.py
+++ b/book/preprocessors/test_rhizz.py
@@ -1,0 +1,243 @@
+"""Unit tests for the book.lock mechanics inside the rhizz mdbook preprocessor.
+
+These test the pure functions (normalization, lock comparison, chapter
+transformation) without mdbook or the rhizz binary.
+
+Run from the repo root with:
+    python3 -m unittest discover -s book/preprocessors -v
+"""
+
+import json
+import os
+import unittest
+
+import rhizz  # same directory (unittest discover adds it to sys.path)
+
+
+def sample_raw() -> dict:
+    """A realistic raw `--json build` output (failing model)."""
+    return {
+        "errors": [
+            {"code": "E011", "file": "/tmp/rhizz-book-ab12/system.hcl", "message": "connection 'greet' references undefined component 'sender' in 'from'"},
+            {"code": "E011", "file": "/tmp/rhizz-book-ab12/system.hcl", "line": 12, "message": "connection 'greet' references undefined component 'receiver' in 'to'"},
+        ],
+        "warnings": [
+            {"code": "W005", "file": "/tmp/rhizz-book-ab12/system.hcl", "message": "connection 'greet' has 'from' and 'to' pointing to the same component"},
+        ],
+    }
+
+
+class NormalizeOutputTest(unittest.TestCase):
+    def test_drops_file_and_sorts_diagnostics(self):
+        out = rhizz.normalize_output(sample_raw())
+        self.assertEqual(
+            out,
+            {
+                "errors": [
+                    # sorted by (code, line, message): a missing line sorts
+                    # before a present one (None -> -1)
+                    {"code": "E011", "message": "connection 'greet' references undefined component 'sender' in 'from'"},
+                    {"code": "E011", "line": 12, "message": "connection 'greet' references undefined component 'receiver' in 'to'"},
+                ],
+                "warnings": [
+                    {"code": "W005", "message": "connection 'greet' has 'from' and 'to' pointing to the same component"},
+                ],
+            },
+        )
+        # No path may leak into the lock, ever.
+        self.assertNotIn("rhizz-book-", json.dumps(out))
+
+    def test_sorts_reordered_warnings_identically(self):
+        a = rhizz.normalize_output({"errors": [], "warnings": [{"code": "W002", "message": "x"}, {"code": "W001", "message": "y"}]})
+        b = rhizz.normalize_output({"errors": [], "warnings": [{"code": "W001", "message": "y"}, {"code": "W002", "message": "x"}]})
+        self.assertEqual(a, b)
+
+    def test_score_passthrough_when_present(self):
+        raw = {"errors": [], "warnings": [], "score": {"system": "ok", "overall": {"percent": 100.0}, "ports": {"complete": 4, "total": 4}}}
+        out = rhizz.normalize_output(raw)
+        self.assertEqual(out["score"]["overall"]["percent"], 100.0)
+        self.assertEqual(out["score"]["ports"]["complete"], 4)
+
+    def test_no_score_key_when_compilation_failed(self):
+        out = rhizz.normalize_output(sample_raw())
+        self.assertNotIn("score", out)
+
+    def test_tool_error_is_none(self):
+        self.assertIsNone(rhizz.normalize_output({"tool_error": "rhizz exploded"}))
+
+    def test_omits_null_line(self):
+        out = rhizz.normalize_output({"errors": [{"code": "E001", "file": "", "line": None, "message": "m"}], "warnings": []})
+        self.assertEqual(out, {"errors": [{"code": "E001", "message": "m"}], "warnings": []})
+
+    def test_is_deterministic_string(self):
+        first = json.dumps(rhizz.normalize_output(sample_raw()), sort_keys=True)
+        second = json.dumps(rhizz.normalize_output(sample_raw()), sort_keys=True)
+        self.assertEqual(first, second)
+
+
+class TransformChapterTest(unittest.TestCase):
+    def test_records_only_compiled_blocks(self):
+        raw_body = 'project {\n  name = "x"\n}\n'
+        chapter = {
+            "name": "X",
+            "path": "x.md",
+            "content": f"# X\n\n```rhizz\n{raw_body}```\n\n```rhizz,ignore\nignored\n```\n",
+        }
+        # The lock hashes the block body as the joined source lines (the
+        # closing fence is never part of it) — same basis as the compiler sees.
+        body = "project {\n  name = \"x\"\n}"
+        results = {rhizz.body_hash(body): {"errors": [], "warnings": []}}
+        _, blocks = rhizz.transform_chapter(chapter, results)
+
+        self.assertEqual(len(blocks), 1)
+        entry = blocks[("x.md", rhizz.body_hash(body))]
+        self.assertEqual(entry["chapter"], "x.md")
+        self.assertEqual(entry["hcl"], body)
+        self.assertEqual(entry["output"], {"errors": [], "warnings": []})
+
+    def test_changed_content_means_new_key(self):
+        chapter = {"name": "X", "path": "x.md", "content": '# X\n\n```rhizz\nproject {}\n```\n'}
+        results = {rhizz.body_hash("project {}"): {"errors": [], "warnings": []}}
+        _, blocks = rhizz.transform_chapter(chapter, results)
+        self.assertEqual(list(blocks)[0], ("x.md", rhizz.body_hash("project {}")))
+
+    def test_output_none_when_tool_failed(self):
+        chapter = {"name": "X", "path": "x.md", "content": '# X\n\n```rhizz\nproject {}\n```\n'}
+        body = "project {}"
+        results = {rhizz.body_hash(body): {"tool_error": "boom"}}
+        _, blocks = rhizz.transform_chapter(chapter, results)
+        self.assertIsNone(blocks[("x.md", rhizz.body_hash(body))]["output"])
+
+    def test_falls_back_to_source_path(self):
+        chapter = {"name": "Draft", "source_path": "draft.md", "content": '# X\n\n```rhizz\nproject {}\n```\n'}
+        body = "project {}"
+        results = {rhizz.body_hash(body): {"errors": [], "warnings": []}}
+        _, blocks = rhizz.transform_chapter(chapter, results)
+        self.assertEqual(list(blocks)[0], ("draft.md", rhizz.body_hash(body)))
+
+
+class LockPayloadTest(unittest.TestCase):
+    def test_entries_sorted_by_chapter_then_hash(self):
+        entries = [
+            {"chapter": "b.md", "input_sha256": "9" * 64, "hcl": "b", "output": {}},
+            {"chapter": "a.md", "input_sha256": "8" * 64, "hcl": "a", "output": {}},
+        ]
+        payload = rhizz.lock_payload(entries, "rhizz 0.1.0")
+        self.assertEqual([e["chapter"] for e in payload["entries"]], ["a.md", "b.md"])
+        self.assertEqual(payload["format"], rhizz.LOCK_FORMAT)
+        self.assertEqual(payload["rhizz_version"], "rhizz 0.1.0")
+
+    def test_round_trip_is_identical(self):
+        entry = {"chapter": "a.md", "input_sha256": "8" * 64, "hcl": "a", "output": {"errors": [], "warnings": []}}
+        payload = rhizz.lock_payload([entry], "rhizz 0.1.0")
+        text = json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+        again = json.loads(text)
+        self.assertEqual(again, payload)
+
+
+class CompareLockTest(unittest.TestCase):
+    def make_blocks(self, entries):
+        return {(e["chapter"], e["input_sha256"]): e for e in entries}
+
+    def entry(self, chapter, sha64, output, hcl="x"):
+        return {"chapter": chapter, "input_sha256": sha64, "hcl": hcl, "output": output}
+
+    def test_matching_lock_has_no_diffs(self):
+        blocks = self.make_blocks([self.entry("a.md", "1" * 64, {"errors": [], "warnings": []})])
+        lock = rhizz.lock_payload(list(blocks.values()), "rhizz 0.1.0")
+        diffs, notes = rhizz.compare_lock(lock, blocks, "rhizz 0.1.0")
+        self.assertEqual(diffs, [])
+        self.assertEqual(notes, [])
+
+    def test_new_block_detected(self):
+        blocks = self.make_blocks([self.entry("a.md", "1" * 64, {"errors": [], "warnings": []})])
+        lock = rhizz.lock_payload([], "rhizz 0.1.0")
+        diffs, _ = rhizz.compare_lock(lock, blocks, "rhizz 0.1.0")
+        self.assertEqual(len(diffs), 1)
+        self.assertIn("new block", diffs[0])
+        self.assertIn("a.md", diffs[0])
+
+    def test_removed_block_detected(self):
+        blocks = {}
+        lock = rhizz.lock_payload([self.entry("a.md", "1" * 64, {"errors": [], "warnings": []})], "rhizz 0.1.0")
+        diffs, _ = rhizz.compare_lock(lock, blocks, "rhizz 0.1.0")
+        self.assertEqual(len(diffs), 1)
+        self.assertIn("removed", diffs[0])
+
+    def test_changed_output_detected(self):
+        blocks = self.make_blocks([self.entry("a.md", "1" * 64, {"errors": [{"code": "E001", "message": "new"}]})])
+        lock = rhizz.lock_payload(
+            [self.entry("a.md", "1" * 64, {"errors": [{"code": "E002", "message": "old"}]})],
+            "rhizz 0.1.0",
+        )
+        diffs, _ = rhizz.compare_lock(lock, blocks, "rhizz 0.1.0")
+        self.assertEqual(len(diffs), 1)
+        self.assertIn("output changed", diffs[0])
+        self.assertIn("E002", diffs[0])  # lock shows old
+        self.assertIn("E001", diffs[0])  # now shows new
+
+    def test_format_mismatch(self):
+        blocks = self.make_blocks([self.entry("a.md", "1" * 64, {"errors": [], "warnings": []})])
+        lock = rhizz.lock_payload(list(blocks.values()), "rhizz 0.1.0")
+        lock["format"] = 99
+        diffs, _ = rhizz.compare_lock(lock, blocks, "rhizz 0.1.0")
+        self.assertEqual(len(diffs), 1)
+        self.assertIn("format", diffs[0])
+
+    def test_version_drift_is_a_note_not_a_diff(self):
+        blocks = self.make_blocks([self.entry("a.md", "1" * 64, {"errors": [], "warnings": []})])
+        lock = rhizz.lock_payload(list(blocks.values()), "rhizz 0.1.0")
+        diffs, notes = rhizz.compare_lock(lock, blocks, "rhizz 0.2.0")
+        self.assertEqual(diffs, [])
+        self.assertEqual(len(notes), 1)
+        self.assertIn("0.1.0", notes[0])
+
+
+class AcceptFlagTest(unittest.TestCase):
+    def setUp(self):
+        self.saved = os.environ.get("BOOKLOCK_ACCEPT_CHANGES")
+
+    def tearDown(self):
+        if self.saved is None:
+            os.environ.pop("BOOKLOCK_ACCEPT_CHANGES", None)
+        else:
+            os.environ["BOOKLOCK_ACCEPT_CHANGES"] = self.saved
+
+    def test_unset_means_verify(self):
+        os.environ.pop("BOOKLOCK_ACCEPT_CHANGES", None)
+        self.assertFalse(rhizz.accept_changes_enabled())
+
+    def test_truthy_values(self):
+        for value in ("1", "yes", "true", "Y"):
+            os.environ["BOOKLOCK_ACCEPT_CHANGES"] = value
+            self.assertTrue(rhizz.accept_changes_enabled())
+
+    def test_falsey_values(self):
+        for value in ("0", "false", "no", ""):
+            os.environ["BOOKLOCK_ACCEPT_CHANGES"] = value
+            self.assertFalse(rhizz.accept_changes_enabled())
+
+
+class ParseAndHashTest(unittest.TestCase):
+    def test_parse_block_attrs(self):
+        self.assertEqual(rhizz.parse_block_attrs(",ignore"), {"ignore"})
+        self.assertEqual(rhizz.parse_block_attrs("ignore"), {"ignore"})
+        self.assertEqual(rhizz.parse_block_attrs(""), set())
+
+    def test_parse_blocks_roundtrip(self):
+        md = "# T\n\n```rhizz,ignore\nproject {}\n```\n\ntext\n"
+        segments = rhizz.parse_blocks(md.splitlines())
+        self.assertEqual(segments[0], ("text", ["# T", ""]))
+        self.assertEqual(segments[1][0], "block")
+        self.assertEqual(segments[1][1], {"ignore"})
+        self.assertEqual(segments[1][2], ["project {}"])
+        # splitlines() drops the final newline, so no trailing empty line.
+        self.assertEqual(segments[2], ("text", ["", "text"]))
+
+    def test_body_hash_is_deterministic(self):
+        self.assertEqual(rhizz.body_hash("project {}"), rhizz.body_hash("project {}"))
+        self.assertNotEqual(rhizz.body_hash("project {}"), rhizz.body_hash("project { }"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/rhizz-core/src/lib.rs
+++ b/crates/rhizz-core/src/lib.rs
@@ -61,10 +61,11 @@ pub struct CompileResult {
 pub fn compile(sources: &[Source]) -> CompileResult {
     let mut merged = parse::RawFile::default();
     let mut system_files = Vec::new();
+    let mut pre_diagnostics = Vec::new();
 
     for source in sources {
         let path = Path::new(&source.filename);
-        let file = match parse::parse_file(&source.content, path) {
+        let mut file = match parse::parse_file(&source.content, path) {
             Ok(f) => f,
             Err(e) => {
                 return CompileResult {
@@ -73,6 +74,10 @@ pub fn compile(sources: &[Source]) -> CompileResult {
                 };
             }
         };
+        // Non-fatal parse warnings (e.g. W015 unexpected block type) surface
+        // alongside the resolution/validation diagnostics below. Draining
+        // keeps `file` intact for `merge_into`.
+        pre_diagnostics.extend(std::mem::take(&mut file.diagnostics));
         if !file.systems.is_empty() {
             system_files.push(path.to_path_buf());
         }
@@ -84,7 +89,6 @@ pub fn compile(sources: &[Source]) -> CompileResult {
         }
     }
 
-    let mut pre_diagnostics = Vec::new();
     if validate_single_system_model(&system_files, &mut pre_diagnostics) {
         return CompileResult {
             model: None,

--- a/crates/rhizz-core/src/parse.rs
+++ b/crates/rhizz-core/src/parse.rs
@@ -1,6 +1,7 @@
 // Public API consumed by the resolve module.
 
 use crate::model::BorderStyle;
+use crate::{Diagnostic, DiagnosticCode};
 /// Raw (deserialization) model and file-level parsing.
 ///
 /// Two concerns live here:
@@ -40,6 +41,9 @@ pub struct RawFile {
     pub protocols: Vec<Labeled<RawProtocol>>,
     /// All parsed view blocks.
     pub views: Vec<Labeled<RawView>>,
+    /// Non-fatal diagnostics collected while parsing (e.g. W015 for unexpected
+    /// block types). Errors are returned via `Result`; warnings land here.
+    pub diagnostics: Vec<Diagnostic>,
 }
 
 /// Raw project metadata before resolution.
@@ -480,7 +484,10 @@ fn parse_connection(body: &hcl::Body) -> Result<RawConnection> {
 }
 
 /// Parse a `component` block body into a [`RawComponent`].
-fn parse_component(body: &hcl::Body) -> Result<RawComponent> {
+///
+/// Unknown block types inside a component are skipped but recorded as a W015
+/// warning on `diagnostics` (so they surface instead of being silently ignored).
+fn parse_component(body: &hcl::Body, diagnostics: &mut Vec<Diagnostic>) -> Result<RawComponent> {
     let a: ComponentAttrs = attrs(body)?;
     let mut ports = Vec::new();
     let mut instances = Vec::new();
@@ -505,7 +512,12 @@ fn parse_component(body: &hcl::Body) -> Result<RawComponent> {
                     .with_context(|| format!("in connection '{label}'"))?;
                 connections.push(Labeled { label, inner });
             }
-            _ => {}
+            other => {
+                diagnostics.push(Diagnostic::warning(
+                    DiagnosticCode::W015,
+                    format!("unexpected block type '{other}' inside component ignored"),
+                ));
+            }
         }
     }
     Ok(RawComponent {
@@ -534,7 +546,10 @@ fn parse_instance(body: &hcl::Body) -> Result<RawInstance> {
 }
 
 /// Parse a `system` block body into a [`RawSystem`].
-fn parse_system(body: &hcl::Body) -> Result<RawSystem> {
+///
+/// Unknown block types inside a system are skipped but recorded as a W015
+/// warning on `diagnostics` (so they surface instead of being silently ignored).
+fn parse_system(body: &hcl::Body, diagnostics: &mut Vec<Diagnostic>) -> Result<RawSystem> {
     let a: SystemAttrs = attrs(body)?;
     let mut instances = Vec::new();
     let mut connections = Vec::new();
@@ -552,7 +567,12 @@ fn parse_system(body: &hcl::Body) -> Result<RawSystem> {
                     .with_context(|| format!("in connection '{label}'"))?;
                 connections.push(Labeled { label, inner });
             }
-            _ => {}
+            other => {
+                diagnostics.push(Diagnostic::warning(
+                    DiagnosticCode::W015,
+                    format!("unexpected block type '{other}' inside system ignored"),
+                ));
+            }
         }
     }
     Ok(RawSystem {
@@ -616,13 +636,13 @@ pub fn parse_file(src: &str, path: &Path) -> Result<RawFile> {
             }
             "system" => {
                 let label = first_label(block)?;
-                let inner =
-                    parse_system(block.body()).with_context(|| format!("in system '{label}'"))?;
+                let inner = parse_system(block.body(), &mut file.diagnostics)
+                    .with_context(|| format!("in system '{label}'"))?;
                 file.systems.push(Labeled { label, inner });
             }
             "component" => {
                 let label = first_label(block)?;
-                let inner = parse_component(block.body())
+                let inner = parse_component(block.body(), &mut file.diagnostics)
                     .with_context(|| format!("in component '{label}'"))?;
                 file.components.push(Labeled { label, inner });
             }
@@ -664,6 +684,7 @@ pub(crate) fn merge_into(dst: &mut RawFile, src: RawFile, path: &Path) -> Result
     dst.components.extend(src.components);
     dst.protocols.extend(src.protocols);
     dst.views.extend(src.views);
+    dst.diagnostics.extend(src.diagnostics);
     Ok(())
 }
 
@@ -988,6 +1009,69 @@ mod tests {
             err.to_string().contains("E010"),
             "expected E010 error, got: {err}"
         );
+    }
+
+    #[test]
+    fn w015_unknown_block_in_system_is_warning_not_silent() {
+        // The old inline grammar — a `component` nested directly inside a
+        // `system` — must surface as a W015 warning, not a hard parse error.
+        let src = r#"
+            system "app" {
+              component "sender" { leaf = true }
+            }
+        "#;
+        let path = PathBuf::from("test.hcl");
+        let file = parse_file(src, &path).unwrap();
+        let w015: Vec<_> = file
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.code == "W015")
+            .collect();
+        assert_eq!(w015.len(), 1, "expected exactly one W015, got {w015:?}");
+        assert!(
+            w015[0].message.contains("component"),
+            "expected the message to name the block type: {}",
+            w015[0].message
+        );
+        // The nested component is ignored, so the system still parses (no hard error).
+        assert_eq!(file.systems.len(), 1);
+        assert_eq!(file.systems[0].inner.instances.len(), 0);
+    }
+
+    #[test]
+    fn w015_unknown_block_in_component_is_warning() {
+        let src = r#"
+            component "board" {
+              component "chip" { leaf = true }
+            }
+        "#;
+        let path = PathBuf::from("test.hcl");
+        let file = parse_file(src, &path).unwrap();
+        let w015: Vec<_> = file
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.code == "W015")
+            .collect();
+        assert_eq!(w015.len(), 1, "expected exactly one W015, got {w015:?}");
+        assert!(w015[0].message.contains("component"));
+    }
+
+    #[test]
+    fn w015_is_emitted_once_per_unknown_block() {
+        let src = r#"
+            system "s" {
+              component "a" {}
+              component "b" {}
+            }
+        "#;
+        let path = PathBuf::from("test.hcl");
+        let file = parse_file(src, &path).unwrap();
+        let count = file
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.code == "W015")
+            .count();
+        assert_eq!(count, 2, "expected one W015 per skipped block");
     }
 
     // ── Inline unit parse tests ─────────────────────────────────────────────


### PR DESCRIPTION
The mdbook preprocessor compiles every ```rhizz block with the current CLI and now traces each block from its HCL input to its normalized compiler output in book/book.lock (keyed by chapter path + sha256 of the input).

- Normalization makes comparison deterministic: diagnostics sorted by (code, line, message), tempdir `file` paths dropped, lock emitted as key-sorted indented JSON. Output drift, new blocks and removed blocks are reported per-entry and abort the build (mdbook exits 101).
- BOOKLOCK_ACCEPT_CHANGES=1 regenerates book.lock in place; regeneration is byte-identical when outputs are unchanged (verified).
- Degraded environments (missing binary, per-block tool failures) never lock or verify — the book hard-requires a working compiler now.
- Metadata (lock format, rhizz version) is stored for humans and never compared.
- Unit tests for the lock mechanics (25 tests, stdlib unittest) wired into `just test`; `just book` / `just book-accept` recipes added; CI gains a `book` job that builds the book against the committed lock.

Book content (examples still use pre-instance grammar) is locked in its current state; updating the chapters is a separate change.