### PR TITLE
feat(core): scope connectivity warnings to placed instances

### DIFF
--- a/SPEC/diagnostics/W001.md
+++ b/SPEC/diagnostics/W001.md
@@ -4,13 +4,16 @@ A component that is not marked `leaf = true` has no child `component` blocks.
 This usually means the decomposition is incomplete — the component is intended
 to be broken down further but hasn't been yet.
 
+This structural check applies to **definitions only** (`component
+"<label>" { ... }`): an instance clones its definition's body, so a
+structural defect is reported once on the definition, never duplicated per
+instance.
+
 ## Example (warning)
 
 ```hcl
-system "drone" {
-  component "flight-controller" {
-    description = "Central flight management unit"
-  }
+component "flight-controller" {
+  description = "Central flight management unit"
 }
 ```
 
@@ -22,10 +25,8 @@ Either decompose the component into children, or mark it as a leaf if it is
 intentionally atomic.
 
 ```hcl
-system "drone" {
-  component "flight-controller" {
-    description = "Central flight management unit"
-    leaf = true
-  }
+component "flight-controller" {
+  description = "Central flight management unit"
+  leaf = true
 }
 ```

--- a/SPEC/diagnostics/W003.md
+++ b/SPEC/diagnostics/W003.md
@@ -1,32 +1,45 @@
 # W003 — Orphan component
 
-A component is not referenced by any `connection` block's `from` or `to`
-attribute within its parent scope. This often indicates a forgotten connection
-or a component that was added but never wired up.
+A **placed instance** (`instance "<local>" { source = "<definition>" }`) is not
+referenced by any `connection` block's `from` or `to` attribute within its
+parent scope. This often indicates a forgotten connection or a component that
+was added but never wired up.
+
+Connectivity warnings apply to instances only: a reusable definition is an
+abstraction and cannot be connected, so it never emits this warning.
 
 ## Example (warning)
 
 ```hcl
+component "sensor" {
+  description = "Reusable definition"
+  leaf        = true
+}
+
 system "drone" {
-  component "motor" { description = "Motor" }
-  component "esc"   { description = "Electronic speed controller" }
+  instance "sensor" { source = "sensor" }
 
   connection "power" {
     from = "esc"
     to   = "motor"
   }
 
-  component "buzzer" {
-    description = "Alert buzzer"
+  instance "buzzer" {
+    source = "buzzer-def"
   }
 }
 ```
 
-`buzzer` is not referenced by any connection.
+`buzzer` is not referenced by any connection. The message names the local
+label with the source definition as secondary context:
+
+```hcl
+component 'buzzer' (source 'buzzer-def') is not referenced by any connection
+```
 
 ## Fix
 
-Connect the orphan component, or remove it if it is not needed.
+Connect the orphan instance, or remove it if it is not needed.
 
 ```hcl
 connection "alert" {

--- a/SPEC/diagnostics/W004.md
+++ b/SPEC/diagnostics/W004.md
@@ -3,25 +3,26 @@
 An entity (system, component, connection, or message) has no `description`
 attribute. Descriptions are important for documentation and readability.
 
+For components, the missing-description check applies to **definitions only**
+(`component "<label>" { ... }`) — an instance clones its definition's body,
+so a description defect is reported once on the definition, never duplicated
+per instance.
+
 ## Example (warning)
 
 ```hcl
-system "drone" {
-  component "motor" {
-  }
+component "motor" {
 }
 ```
 
-`motor` has no description.
+`motor` (a definition) has no description.
 
 ## Fix
 
 Add a `description` attribute.
 
 ```hcl
-system "drone" {
-  component "motor" {
-    description = "Brushless DC motor driving one propeller"
-  }
+component "motor" {
+  description = "Brushless DC motor driving one propeller"
 }
 ```

--- a/SPEC/diagnostics/W010.md
+++ b/SPEC/diagnostics/W010.md
@@ -1,23 +1,32 @@
 # W010 — Unused port
 
-A port is defined on a component but is not referenced by any connection:
+A port is defined on a **placed instance** (`instance "<local>" { source =
+"<definition>" }`) but is not referenced by any connection:
 
 - For **internal ports** (`external = false`): the port is not wired between child components within the component's subtree.
 - For **external ports** (`external = true`, `required = true`): the port is left unconnected when the component is instantiated inside a `system` or parent component. (When verifying an isolated component, unconnected external ports are expected and do not trigger this warning.)
+
+Connectivity warnings apply to instances only: a port on a reusable definition
+is part of the abstraction's contract and cannot be connected, so definition
+ports never emit this warning.
 
 The port may be intentionally reserved for future use, or it may indicate a forgotten connection.
 
 ## Example (warning)
 
 ```hcl
+component "fc" {
+  port "spi"  { protocol = "SPI"; role = "consumer"; external = true }
+  port "uart" { protocol = "UART"; role = "consumer"; external = true; required = true }
+}
+
+component "imu" {
+  port "spi" { protocol = "SPI"; role = "provider"; external = true }
+}
+
 system "drone" {
-  component "fc" {
-    port "spi"  { protocol = "SPI"; role = "consumer"; external = true }
-    port "uart" { protocol = "UART"; role = "consumer"; external = true; required = true }
-  }
-  component "imu" {
-    port "spi" { protocol = "SPI"; role = "provider"; external = true }
-  }
+  instance "fc"  { source = "fc" }
+  instance "imu" { source = "imu" }
 
   connection "imu-link" {
     from = "imu/spi"
@@ -26,19 +35,25 @@ system "drone" {
 }
 ```
 
-`fc/uart` is marked as a required external port on `fc`, but is not connected in system `"drone"`.
+`fc/uart` is marked as a required external port on the `fc` instance, but is not connected in system `"drone"`.
 
 ## Fix
 
 Wire the port to a connection, mark it `required = false` if optional, or remove it if not needed.
 
 ```hcl
-  component "gps" {
-    port "uart" { protocol = "UART"; role = "provider"; external = true }
-  }
+component "gps" {
+  port "uart" { protocol = "UART"; role = "provider"; external = true }
+}
+
+system "drone" {
+  instance "fc"   { source = "fc" }
+  instance "imu"  { source = "imu" }
+  instance "gps"  { source = "gps" }
 
   connection "gps-link" {
     from = "gps/uart"
     to   = "fc/uart"
   }
+}
 ```

--- a/SPEC/models.md
+++ b/SPEC/models.md
@@ -363,7 +363,8 @@ struct Field {
 7. Resolve `encapsulates` — same-scope connection label lookup (E003; E004 for cycles).
 8. Resolve views — look up `system` label → `SystemId` (E006 if missing).
 9. Validation checks:
-   - Unconnected port verification:
+   - Unconnected port verification (applies to **placed instances only**;
+     a definition's ports are part of its contract and cannot be connected):
      - In isolated components: unconnected `external = true` ports are permitted. Unconnected internal (`external = false`) ports emit W010.
      - In instantiated systems: unconnected `external = true, required = true` ports emit W010.
    - Protocol / role compatibility on typed connections (W008, W009).

--- a/book/book.lock
+++ b/book/book.lock
@@ -33,15 +33,11 @@
         "warnings": [
           {
             "code": "W003",
-            "message": "component 'front-wheel' is not referenced by any connection"
+            "message": "component 'front-wheel' (source 'wheel') is not referenced by any connection"
           },
           {
             "code": "W003",
-            "message": "component 'rear-wheel' is not referenced by any connection"
-          },
-          {
-            "code": "W003",
-            "message": "component 'wheel' is not referenced by any connection"
+            "message": "component 'rear-wheel' (source 'wheel') is not referenced by any connection"
           }
         ]
       }
@@ -76,20 +72,7 @@
           },
           "system": ""
         },
-        "warnings": [
-          {
-            "code": "W003",
-            "message": "component 'fork' is not referenced by any connection"
-          },
-          {
-            "code": "W003",
-            "message": "component 'frame' is not referenced by any connection"
-          },
-          {
-            "code": "W003",
-            "message": "component 'wheel' is not referenced by any connection"
-          }
-        ]
+        "warnings": []
       }
     },
     {
@@ -126,10 +109,6 @@
           {
             "code": "W001",
             "message": "component 'wheel' is non-leaf but has no child components"
-          },
-          {
-            "code": "W003",
-            "message": "component 'wheel' is not referenced by any connection"
           }
         ]
       }
@@ -217,20 +196,12 @@
         ],
         "warnings": [
           {
-            "code": "W003",
-            "message": "component 'sensor-hat' is not referenced by any connection"
-          },
-          {
             "code": "W004",
             "message": "connection 'link' is missing a description"
           },
           {
             "code": "W005",
             "message": "connection 'link' has 'from' and 'to' pointing to the same component"
-          },
-          {
-            "code": "W010",
-            "message": "port 'data' is not referenced by any connection"
           },
           {
             "code": "W011",

--- a/crates/rhizz-core/src/validate.rs
+++ b/crates/rhizz-core/src/validate.rs
@@ -1,6 +1,6 @@
 //! Validation pass -- warning pass over the resolved Model.
 
-use crate::model::{ComponentParent, Diagnostic, DiagnosticCode, Model};
+use crate::model::{ComponentKind, ComponentParent, Diagnostic, DiagnosticCode, Model};
 use std::collections::{HashMap, HashSet};
 use tracing::instrument;
 
@@ -14,8 +14,14 @@ use tracing::instrument;
 pub fn validate(model: &Model) -> Vec<Diagnostic> {
     let mut warnings: Vec<Diagnostic> = Vec::new();
 
-    // W001 -- non-leaf component with no child components (decomposition pending)
+    // W001 -- non-leaf component with no child components (decomposition
+    // pending). Only definitions are checked: an instance clones the
+    // definition's body, so a structural defect would be reported on the
+    // definition itself and must not be duplicated per instance.
     for comp in &model.components {
+        if comp.kind == ComponentKind::Instance {
+            continue;
+        }
         if !comp.leaf && comp.children.is_empty() {
             warnings.push(Diagnostic::warning(
                 DiagnosticCode::W001,
@@ -37,19 +43,28 @@ pub fn validate(model: &Model) -> Vec<Diagnostic> {
         }
     }
 
-    // W003 -- component is not referenced by any connection (orphan)
+    // W003 -- placed instance is not referenced by any connection (orphan).
+    // Reusable definitions are abstractions that cannot be connected, so only
+    // instances are checked; the source definition is appended for context.
     let mut referenced: HashSet<usize> = HashSet::new();
     for conn in &model.connections {
         referenced.insert(conn.from.component.0);
         referenced.insert(conn.to.component.0);
     }
     for (cid, comp) in model.components.iter().enumerate() {
+        if comp.kind == ComponentKind::Definition {
+            continue;
+        }
         if !referenced.contains(&cid) {
+            let source_suffix = comp
+                .source
+                .as_deref()
+                .map_or_else(String::new, |source| format!(" (source '{source}')"));
             warnings.push(Diagnostic::warning(
                 DiagnosticCode::W003,
                 format!(
-                    "component '{}' is not referenced by any connection",
-                    comp.label
+                    "component '{}'{} is not referenced by any connection",
+                    comp.label, source_suffix
                 ),
             ));
         }
@@ -65,6 +80,9 @@ pub fn validate(model: &Model) -> Vec<Diagnostic> {
         }
     }
     for comp in &model.components {
+        if comp.kind == ComponentKind::Instance {
+            continue;
+        }
         if comp.description.is_empty() {
             warnings.push(Diagnostic::warning(
                 DiagnosticCode::W004,
@@ -196,6 +214,15 @@ pub fn validate(model: &Model) -> Vec<Diagnostic> {
         }
     }
     for (idx, port) in model.ports.iter().enumerate() {
+        // Connectivity warnings apply to placed instances only; a definition's
+        // port is part of an abstraction's contract and cannot be connected.
+        let owner = model
+            .components
+            .get(port.owner.0)
+            .map_or(ComponentKind::Definition, |comp| comp.kind);
+        if owner != ComponentKind::Instance {
+            continue;
+        }
         if !used_ports.contains(&idx) {
             // Unconnected ports emit W010 unless marked as an optional external port (external = true, required = false)
             if !port.external || port.required {
@@ -584,6 +611,136 @@ mod tests {
         assert!(
             warnings.iter().any(|d| d.code == DiagnosticCode::W010),
             "unconnected internal port must emit W010, got: {:?}",
+            warning_codes(&warnings)
+        );
+    }
+
+    // ── Definition vs instance scoping of W001/W003/W004/W010 ─────────────
+
+    #[test]
+    fn w003_not_emitted_for_definitions() {
+        let src = r#"
+            component "sensor" {
+              description = "Reusable definition"
+              leaf = true
+              port "data" { protocol = "sig" }
+            }
+        "#;
+        let raw = crate::parse::parse_file(src, std::path::Path::new("test.hcl")).unwrap();
+        let (model, _) = resolve(raw).unwrap();
+        let warnings = validate(&model);
+        assert!(
+            !warnings.iter().any(|d| d.code == DiagnosticCode::W003),
+            "a definition must never emit W003, got: {:?}",
+            warning_codes(&warnings)
+        );
+        assert_eq!(model.components.len(), 1);
+        assert_eq!(
+            model.components[0].kind,
+            crate::model::ComponentKind::Definition
+        );
+    }
+
+    #[test]
+    fn w003_emitted_for_unconnected_instance_with_source_suffix() {
+        let src = r#"
+            component "sensor" {
+              description = "Reusable definition"
+              leaf = true
+            }
+            system "s" {
+              instance "sensor" { source = "sensor" }
+            }
+        "#;
+        let raw = crate::parse::parse_file(src, std::path::Path::new("test.hcl")).unwrap();
+        let (model, _) = resolve(raw).unwrap();
+        let warnings = validate(&model);
+        let w003: Vec<&Diagnostic> = warnings
+            .iter()
+            .filter(|d| d.code == DiagnosticCode::W003)
+            .collect();
+        assert_eq!(
+            w003.len(),
+            1,
+            "expected one W003, got: {:?}",
+            warning_codes(&warnings)
+        );
+        assert!(
+            w003[0]
+                .message
+                .contains("component 'sensor' (source 'sensor') is not referenced"),
+            "W003 should name the local label with source context: {}",
+            w003[0].message
+        );
+    }
+
+    #[test]
+    fn w010_not_emitted_for_definition_ports() {
+        let src = r#"
+            component "sensor" {
+              description = "Reusable definition"
+              leaf = true
+              port "data" { protocol = "sig" }
+            }
+        "#;
+        let raw = crate::parse::parse_file(src, std::path::Path::new("test.hcl")).unwrap();
+        let (model, _) = resolve(raw).unwrap();
+        let warnings = validate(&model);
+        assert!(
+            !warnings.iter().any(|d| d.code == DiagnosticCode::W010),
+            "a definition port must never emit W010, got: {:?}",
+            warning_codes(&warnings)
+        );
+    }
+
+    #[test]
+    fn w001_and_w004_emitted_once_for_definition_not_per_instance() {
+        let src = r#"
+            component "motor" {
+              description = ""
+              leaf = false
+            }
+            system "s" {
+              instance "m1" { source = "motor" }
+              instance "m2" { source = "motor" }
+            }
+        "#;
+        let raw = crate::parse::parse_file(src, std::path::Path::new("test.hcl")).unwrap();
+        let (model, _) = resolve(raw).unwrap();
+        let warnings = validate(&model);
+        // Structural and description warnings come from the definition only,
+        // once each, even though two instances clone the (empty) body.
+        let w001: Vec<&Diagnostic> = warnings
+            .iter()
+            .filter(|d| d.code == DiagnosticCode::W001)
+            .collect();
+        let w004: Vec<&Diagnostic> = warnings
+            .iter()
+            .filter(|d| d.code == DiagnosticCode::W004 && d.message.contains("component"))
+            .collect();
+        assert_eq!(
+            w001.len(),
+            1,
+            "expected exactly one W001, got: {:?}",
+            warning_codes(&warnings)
+        );
+        assert_eq!(
+            w004.len(),
+            1,
+            "expected exactly one component-W004, got: {:?}",
+            warning_codes(&warnings)
+        );
+        assert!(w001[0].message.contains("motor"));
+        assert!(w004[0].message.contains("motor"));
+        // The two unconnected instances still each emit W003.
+        let w003_count = warnings
+            .iter()
+            .filter(|d| d.code == DiagnosticCode::W003)
+            .count();
+        assert_eq!(
+            w003_count,
+            2,
+            "expected two W003, got: {:?}",
             warning_codes(&warnings)
         );
     }


### PR DESCRIPTION
Connectivity warnings are meaningless for reusable definitions, which are abstractions that cannot be connected (Task 100's instance model). W003 and W010 now fire on instances only; W001 and W004 (component) fire on definitions only, which also eliminates duplicate reports that appeared on every cloned instance. W003 message names the local instance label with the source definition as secondary context: component 'sensor' (source 'sensordef') is not referenced by any connection. Updates SPEC W001/W003/W004/W010 md + models.md, regenerates book.lock (greeter/sketch/wiring-bug outputs changed as intended: definition-side W003/W010 dropped). Scoring untouched. 199 Rust tests + clippy + fmt green.