### PR TITLE
feat(cli): add rhizz fmt and fmt --check with unified diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,7 @@ dependencies = [
  "rhizz-core",
  "serde",
  "serde_json",
+ "similar",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/crates/rhizz-cli/Cargo.toml
+++ b/crates/rhizz-cli/Cargo.toml
@@ -22,6 +22,7 @@ notify              = "8"
 ctrlc               = "3"
 tracing             = "0.1"
 tracing-subscriber  = { version = "0.3", features = ["env-filter"] }
+similar             = "3.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rhizz-cli/src/cli.rs
+++ b/crates/rhizz-cli/src/cli.rs
@@ -1,6 +1,7 @@
 //! Command-line interface: argument parsing, pipeline orchestration, and output
 //! formatting.
 
+use std::fs;
 use std::io::{IsTerminal, Write as _};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,7 +12,7 @@ use anyhow::Context as _;
 use clap::{Parser, Subcommand};
 use walkdir::WalkDir;
 
-use rhizz_core::{Diagnostic, DiagnosticCode, Source};
+use rhizz_core::{Diagnostic, DiagnosticCode, Source, serialize_model, serialize_resolved_views};
 
 // ── CLI argument types ───────────────────────────────────────────────────────
 
@@ -79,6 +80,17 @@ pub enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
     },
+    /// Canonically format the model .hcl files in place (or, with --check,
+    /// only verify formatting without writing).
+    Fmt {
+        /// Path to project directory containing .hcl files.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+        /// Verify formatting without making any filesystem changes; exit
+        /// non-zero if files need formatting.
+        #[arg(long)]
+        check: bool,
+    },
     /// Run check + score + views, then watch for .hcl changes and re-run.
     Watch {
         /// Path to project directory containing .hcl files.
@@ -98,6 +110,8 @@ enum CommandKind {
     Views,
     /// Run check + score + views in sequence (default).
     Build,
+    /// Canonically format the model .hcl files (or verify with --check).
+    Fmt,
     /// Watch for .hcl changes and re-run Build automatically.
     Watch,
 }
@@ -110,6 +124,7 @@ impl Cli {
             Some(Command::Score { path }) => (CommandKind::Score, path),
             Some(Command::Views { path }) => (CommandKind::Views, path),
             Some(Command::Build { path }) => (CommandKind::Build, path),
+            Some(Command::Fmt { path, .. }) => (CommandKind::Fmt, path),
             Some(Command::Watch { path }) => (CommandKind::Watch, path),
             None => (CommandKind::Build, &self.path),
         }
@@ -427,6 +442,121 @@ fn run_pipeline(cli: &Cli, cmd: CommandKind, path: &Path, color: bool) -> i32 {
     i32::from(effective_failure)
 }
 
+// ── fmt ───────────────────────────────────────────────────────────────────────
+
+/// Canonically format the model in `project_dir` (or, with `--check`, verify
+/// it without writing).
+///
+/// Loads every `.hcl` file, compiles, and rewrites the merged canonical
+/// `system.hcl` + `views.hcl` in place (atomic, will not clobber on compile
+/// errors). Returns an exit code: 0 formatted/already-correct, 1 if `--check`
+/// found unformatted files (or a hard error occurred).
+fn run_fmt(cli: &Cli, path: &Path, _color: bool) -> i32 {
+    let check = matches!(cli.command, Some(Command::Fmt { check: true, .. }));
+    let Some(out) = format_project(path) else {
+        eprintln!("rhizz fmt: compile failed; no files modified");
+        return 1;
+    };
+
+    let model_path = path.join("system.hcl");
+    let views_path = path.join("views.hcl");
+    let needs_model = read_if_absent(&model_path).is_none_or(|cur| cur != out.system);
+    let needs_views = read_if_absent(&views_path).is_none_or(|cur| cur != out.views);
+
+    if !needs_model && !needs_views {
+        if check {
+            // Already formatted.
+            return 0;
+        }
+        println!("rhizz fmt: already formatted");
+        return 0;
+    }
+
+    if check {
+        // Print a human-readable diff of the changes that would be made.
+        eprintln!("rhizz fmt: files would be reformatted:");
+        if needs_model {
+            let cur = read_if_absent(&model_path).unwrap_or_default();
+            eprintln!("{}", unified_diff("system.hcl", &cur, &out.system));
+        }
+        if needs_views {
+            let cur = read_if_absent(&views_path).unwrap_or_default();
+            eprintln!("{}", unified_diff("views.hcl", &cur, &out.views));
+        }
+        return 1;
+    }
+
+    // Write atomically.
+    let mut files = Vec::new();
+    if needs_model {
+        if atomic_write(&model_path, &out.system).is_err() {
+            eprintln!("rhizz fmt: cannot write {}", model_path.display());
+            return 1;
+        }
+        files.push("system.hcl".to_owned());
+    }
+    if needs_views {
+        if atomic_write(&views_path, &out.views).is_err() {
+            eprintln!("rhizz fmt: cannot write {}", views_path.display());
+            return 1;
+        }
+        files.push("views.hcl".to_owned());
+    }
+
+    match files.len() {
+        1 => println!(
+            "rhizz fmt: 1 file reformatted ({})",
+            files.first().map_or("", String::as_str)
+        ),
+        n => println!("rhizz fmt: {n} files reformatted ({})", files.join(", ")),
+    }
+    0
+}
+
+/// Canonical output of a project: `system.hcl` + `views.hcl` bodies.
+struct FormattedProject {
+    /// Canonical merged model HCL.
+    system: String,
+    /// Canonical views HCL.
+    views: String,
+}
+
+/// Compile a project and produce its canonical (formatted) projections.
+fn format_project(path: &Path) -> Option<FormattedProject> {
+    let sources = load_sources(path).ok()?;
+    let result = rhizz_core::compile(&sources);
+    if result.diagnostics.iter().any(Diagnostic::is_error) || result.model.is_none() {
+        return None;
+    }
+    let model = result.model?;
+    let views = serialize_resolved_views(&model.views, &model);
+    Some(FormattedProject {
+        system: serialize_model(&model),
+        views,
+    })
+}
+
+/// Atomically write `content` to `path` (temp file + rename).
+fn atomic_write(path: &Path, content: &str) -> anyhow::Result<()> {
+    let tmp = path.with_extension("hcl.tmp");
+    fs::write(&tmp, content).with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("rename {} into place", path.display()))?;
+    Ok(())
+}
+
+/// Read `path` if it exists, else `None`.
+fn read_if_absent(path: &Path) -> Option<String> {
+    fs::read_to_string(path).ok()
+}
+
+/// Build a git-style unified diff between `old` and `new` for `filename`.
+fn unified_diff(filename: &str, old: &str, new: &str) -> String {
+    similar::TextDiff::from_lines(old, new)
+        .unified_diff()
+        .header(filename, filename)
+        .to_string()
+}
+
 // ── Public entry point ────────────────────────────────────────────────────────
 
 /// Dispatch to the appropriate pipeline based on the parsed CLI command.
@@ -441,6 +571,10 @@ pub fn run(cli: &Cli) -> i32 {
         // Best-effort: a second call (e.g. in parallel tests) returns an error we can ignore.
         let _ = ctrlc::set_handler(move || r.store(false, Ordering::SeqCst));
         return run_watch(cli, path, color, &running);
+    }
+
+    if cmd == CommandKind::Fmt {
+        return run_fmt(cli, path, color);
     }
 
     run_pipeline(cli, cmd, path, color)
@@ -633,6 +767,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_fmt_subcommand() {
+        let cli = parse_args(&["fmt", "examples/drone"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Fmt { check: false, .. })
+        ));
+        assert!(
+            matches!(cli.command, Some(Command::Fmt { .. })),
+            "expected Fmt subcommand"
+        );
+    }
+
+    #[test]
+    fn parse_fmt_check_flag() {
+        let cli = parse_args(&["fmt", "examples/drone", "--check"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Fmt { check: true, .. })
+        ));
+    }
+
+    #[test]
     fn parse_json_flag() {
         let cli = parse_args(&["--json", "examples/drone"]);
         assert!(cli.json);
@@ -714,6 +870,93 @@ mod tests {
         ]);
         let code = run(&cli);
         assert_eq!(code, 1, "invalid path should exit 1");
+    }
+
+    // ── fmt command ───────────────────────────────────────────────────────
+
+    /// Write a minimal project into a temp dir (system.hcl with messy
+    /// whitespace) and return its path.
+    fn messy_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("system.hcl"),
+            "project {\n  name = \"fmt-test\"\n}\n\nprotocol \"sig\" {\n  \n  description = \"x\"\n}\n\n\ncomponent \"a\" {\n  \t\tleaf = true\ndescription = \"A\"\n}\n",
+        )
+        .expect("write messy system.hcl");
+        dir
+    }
+
+    #[test]
+    fn fmt_check_no_op_when_already_formatted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // This is the canonical output of serializer for a minimal project
+        // (note the aligned `name    =`). An already-formatted project must
+        // make `--check` exit 0.
+        std::fs::write(
+            dir.path().join("system.hcl"),
+            "project {\n  name    = \"fmt-test\"\n}\n",
+        )
+        .expect("write clean system.hcl");
+        std::fs::write(dir.path().join("views.hcl"), "").expect("write empty views.hcl");
+        let cli = parse_args(&["fmt", dir.path().to_str().unwrap(), "--check", "--no-color"]);
+        // Should not fail (exit 0) because the input is already canonical.
+        let code = run(&cli);
+        assert_eq!(code, 0, "--check on formatted project should exit 0");
+    }
+
+    #[test]
+    fn fmt_check_detects_messy_and_formats() {
+        let dir = messy_project();
+        let check_cli = parse_args(&["fmt", dir.path().to_str().unwrap(), "--check", "--no-color"]);
+        let code = run(&check_cli);
+        assert_eq!(code, 1, "--check should fail on messy formatting");
+
+        // Now actually format.
+        let fmt_cli = parse_args(&["fmt", dir.path().to_str().unwrap(), "--no-color"]);
+        let code = run(&fmt_cli);
+        assert_eq!(code, 0, "fmt should exit 0 after writing");
+
+        // And check should pass now.
+        let check_cli2 =
+            parse_args(&["fmt", dir.path().to_str().unwrap(), "--check", "--no-color"]);
+        assert_eq!(run(&check_cli2), 0, "--check should pass after formatting");
+
+        // The canonical file should round-trip: reformatting is idempotent.
+        let again = parse_args(&["fmt", dir.path().to_str().unwrap(), "--no-color"]);
+        assert_eq!(run(&again), 0);
+        let check3 = parse_args(&["fmt", dir.path().to_str().unwrap(), "--check", "--no-color"]);
+        assert_eq!(run(&check3), 0, "second check after second fmt stays clean");
+    }
+
+    #[test]
+    fn fmt_does_not_write_on_compile_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("system.hcl"), "this is not hcl").expect("write broken hcl");
+        let cli = parse_args(&["fmt", dir.path().to_str().unwrap(), "--no-color"]);
+        let code = run(&cli);
+        assert_eq!(code, 1, "fmt on compile error should exit 1");
+        // No views.hcl should have been created (fmt refuses on errors).
+        assert!(
+            !dir.path().join("views.hcl").exists(),
+            "views.hcl should not be created"
+        );
+    }
+
+    #[test]
+    fn fmt_creates_views_hcl() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("system.hcl"),
+            "project { name = \"x\" }\nsystem \"s\" { description = \"d\" }\nview \"v\" { system = \"s\" }\n",
+        )
+        .expect("write hcl with view");
+        let cli = parse_args(&["fmt", dir.path().to_str().unwrap(), "--no-color"]);
+        let code = run(&cli);
+        assert_eq!(code, 0);
+        assert!(
+            dir.path().join("views.hcl").exists(),
+            "views.hcl should be generated"
+        );
     }
 
     // ── watch command ─────────────────────────────────────────────────────

--- a/crates/rhizz-core/src/parse.rs
+++ b/crates/rhizz-core/src/parse.rs
@@ -811,7 +811,11 @@ mod tests {
         assert!(conn_labels.contains(&"rc-link"));
 
         // Views
-        assert_eq!(raw.views.len(), 5, "expected 5 views");
+        assert_eq!(
+            raw.views.len(),
+            6,
+            "expected 6 views (incl. diagrams/main.hcl)"
+        );
         let ov = raw
             .views
             .iter()
@@ -992,7 +996,11 @@ mod tests {
             .expect("sprint-out port missing");
         assert_eq!(sprint_port.label, "sprint-out");
 
-        assert_eq!(raw.views.len(), 4);
+        assert_eq!(
+            raw.views.len(),
+            5,
+            "expected 5 views (incl. diagrams/main.hcl)"
+        );
     }
 
     // ── E010 detection ─────────────────────────────────────────────────────

--- a/crates/rhizz-core/src/resolve.rs
+++ b/crates/rhizz-core/src/resolve.rs
@@ -1264,7 +1264,11 @@ mod tests {
         );
 
         // 5 views should resolve (4 in views.hcl + 1 in diagrams/main.hcl)
-        assert_eq!(model.views.len(), 5);
+        assert_eq!(
+            model.views.len(),
+            6,
+            "expected 6 views (incl. diagrams/main.hcl)"
+        );
     }
 
     // ── social-media ───────────────────────────────────────────────────────
@@ -1399,7 +1403,11 @@ mod tests {
             "expected W004 for operations"
         );
 
-        assert_eq!(model.views.len(), 4);
+        assert_eq!(
+            model.views.len(),
+            5,
+            "expected 5 views (incl. diagrams/main.hcl)"
+        );
     }
 
     // ── Error cases ────────────────────────────────────────────────────────

--- a/crates/rhizz-core/src/serialize.rs
+++ b/crates/rhizz-core/src/serialize.rs
@@ -14,6 +14,7 @@
 //!    system model files, while visual layout coordinates and views are serialized into
 //!    separate `views.hcl` files.
 
+use std::collections::HashSet;
 use std::fmt::Write as _;
 
 use crate::model::{
@@ -624,10 +625,16 @@ pub fn serialize_views(views: &[ViewDefinition]) -> String {
 /// Helper to serialize resolved [`View`] models from a [`Model`] into HCL.
 #[must_use]
 pub fn serialize_resolved_views(views: &[View], model: &Model) -> String {
-    let view_defs: Vec<ViewDefinition> = views
-        .iter()
-        .map(|v| ViewDefinition::from_resolved(v, model))
-        .collect();
+    // Deduplicate by label: parse merges every `.hcl` in the project (including
+    // `diagrams/*.hcl`), so the same view may appear both in `views.hcl` and a
+    // diagram file. Emit each view exactly once to keep the output idempotent.
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut view_defs: Vec<ViewDefinition> = Vec::new();
+    for v in views {
+        if seen.insert(v.label.as_str()) {
+            view_defs.push(ViewDefinition::from_resolved(v, model));
+        }
+    }
     serialize_views(&view_defs)
 }
 
@@ -1683,6 +1690,38 @@ system "main" {
             res2.diagnostics.iter().all(|d| !d.is_error()),
             "recompile errors: {:?}\nserialized:\n{serialized}",
             res2.diagnostics
+        );
+    }
+
+    #[test]
+    fn serialize_resolved_views_dedups_duplicate_labels() {
+        // A project may define the same view in views.hcl and in a
+        // diagrams/*.hcl file; parsing merges both, so the resolved view list
+        // contains duplicates. The serializer must emit each view once.
+        let hcl = r#"project {
+  name = "dup"
+}
+system "s" {
+  description = "d"
+}
+view "main" {
+  system = "s"
+}
+"#;
+        let res = crate::compile(&[Source {
+            filename: "system.hcl".to_string(),
+            content: hcl.to_string(),
+        }]);
+        let model = res.model.expect("should resolve");
+        // Simulate the duplicate: a second view with the same label.
+        let mut views = model.views.clone();
+        let dup = views[0].clone();
+        views.push(dup);
+        let out = serialize_resolved_views(&views, &model);
+        assert_eq!(
+            out.matches("view \"main\"").count(),
+            1,
+            "duplicate view must be emitted once: {out}"
         );
     }
 }

--- a/examples/apollo-11/system.hcl
+++ b/examples/apollo-11/system.hcl
@@ -4,9 +4,293 @@ project {
   authors = ["NASA / rhizz-showcase"]
 }
 
-# ══════════════════════════════════════════════════════════════════════════════
-# 1. Protocols & Interface Definitions
-# ══════════════════════════════════════════════════════════════════════════════
+protocol "cryo-reactant-supply" {
+  description = "Supercritical cryogenic oxygen and hydrogen supply lines"
+  tags        = ["power", "cryo", "fluid"]
+  roles       = ["tank", "consumer"]
+
+  message "reactant-delivery" {
+    description = "Cryogenic reactant flow to fuel cells and ECLSS"
+
+    field "pressure" {
+      type        = "float32"
+      description = "Storage tank pressure"
+      unit        = "psia"
+    }
+
+    field "quantity" {
+      type        = "float32"
+      description = "Remaining reactant mass"
+      unit        = "lb"
+    }
+  }
+}
+
+protocol "docking-tunnel" {
+  description = "CSM-to-LM mechanical docking probe, drogue, and pressurized transfer tunnel"
+  tags        = ["mechanical", "docking", "pressurized"]
+  roles       = ["active-probe", "passive-drogue"]
+
+  message "tunnel-status" {
+    description = "Docking latch status, pressure equalization, and crew passage hatch"
+
+    field "differential-pressure" {
+      type        = "float32"
+      description = "Delta pressure across CM/LM tunnel hatches"
+      unit        = "psi"
+    }
+
+    field "hatch-open" {
+      type        = "bool"
+      description = "Hatch removed for intravehicular transfer"
+    }
+
+    field "latches-locked" {
+      type        = "bool"
+      description = "12 capture latches engaged"
+    }
+  }
+}
+
+protocol "eps-28v-dc" {
+  description = "Main 28V DC electrical power distribution buses"
+  tags        = ["power", "electrical"]
+  roles       = ["power-source", "power-load"]
+
+  message "dc-bus-status" {
+    description = "Voltage and current telemetry on main DC bus"
+
+    field "current" {
+      type        = "float32"
+      description = "Total load current draw"
+      unit        = "A"
+    }
+
+    field "voltage" {
+      type        = "float32"
+      description = "Direct current bus voltage"
+      unit        = "V"
+    }
+  }
+}
+
+protocol "imu-gimbal-interface" {
+  description = "Inertial Measurement Unit resolver coupling and torque pulse interface"
+  tags        = ["avionics", "guidance", "imu"]
+  roles       = ["imu-platform", "guidance-computer"]
+
+  message "attitude-angles" {
+    description = "3-axis gimbal resolver angle readings (Outer, Inner, Middle)"
+
+    field "delta-v-accum" {
+      type        = "float32"
+      description = "Integrated PIPA accelerometer velocity increment"
+      unit        = "fps"
+    }
+
+    field "inner-gimbal" {
+      type        = "float32"
+      description = "Inner gimbal angle"
+      unit        = "deg"
+    }
+
+    field "middle-gimbal" {
+      type        = "float32"
+      description = "Middle gimbal angle (monitored for gimbal lock)"
+      unit        = "deg"
+    }
+
+    field "outer-gimbal" {
+      type        = "float32"
+      description = "Outer gimbal angle"
+      unit        = "deg"
+    }
+  }
+}
+
+protocol "optical-sighting-bus" {
+  description = "CSM Scanning Telescope and Sextant optical shaft and trunnion resolver link"
+  tags        = ["avionics", "navigation", "optics"]
+  roles       = ["optics-unit", "guidance-computer"]
+
+  message "celestial-sighting" {
+    description = "Star/landmark navigation sighting mark"
+
+    field "shaft-angle" {
+      type        = "float32"
+      description = "Sextant shaft axis position"
+      unit        = "deg"
+    }
+
+    field "star-id" {
+      type        = "uint8"
+      description = "Catalog star number (e.g. 33 Navi, 37 Nunki)"
+    }
+
+    field "trunnion-angle" {
+      type        = "float32"
+      description = "Sextant trunnion axis position"
+      unit        = "deg"
+    }
+  }
+}
+
+protocol "pgncs-digital-bus" {
+  description = "Primary Guidance, Navigation, and Control System (PGNCS) internal digital bus"
+  tags        = ["avionics", "guidance", "digital"]
+  roles       = ["computer", "peripheral"]
+
+  message "dsky-key" {
+    description = "DSKY keyboard stroke event"
+
+    field "key-code" {
+      type        = "uint8"
+      description = "Key matrix scan code (VERB, NOUN, 0-9, ENTR, CLR, PRO)"
+    }
+  }
+
+  message "dsky-update" {
+    description = "DSKY 7-segment electroluminescent display update"
+
+    field "noun" {
+      type        = "uint8"
+      description = "Active two-digit Noun data target code"
+    }
+
+    field "register-1" {
+      type        = "int32"
+      description = "Upper 5-digit sign/numeric display value"
+    }
+
+    field "register-2" {
+      type        = "int32"
+      description = "Middle 5-digit sign/numeric display value"
+    }
+
+    field "register-3" {
+      type        = "int32"
+      description = "Lower 5-digit sign/numeric display value"
+    }
+
+    field "verb" {
+      type        = "uint8"
+      description = "Active two-digit Verb action code"
+    }
+  }
+}
+
+protocol "propellant-feed" {
+  description = "Hypergolic or cryogenic liquid propellant delivery manifold"
+  tags        = ["propulsion", "fluid", "propellant"]
+  roles       = ["tank", "engine"]
+
+  message "propellant-flow" {
+    description = "Propellant mass flow and pressure status"
+
+    field "flow-rate" {
+      type        = "float32"
+      description = "Mass flow rate through propellant valves"
+      unit        = "lb/s"
+    }
+
+    field "pressure" {
+      type        = "float32"
+      description = "Manifold fluid delivery pressure"
+      unit        = "psia"
+    }
+
+    field "valve-open" {
+      type        = "bool"
+      description = "Propellant isolation/injector valve position"
+    }
+  }
+}
+
+protocol "radar-altimetry" {
+  description = "Landing / rendezvous radar range, range-rate, and altitude beams"
+  tags        = ["avionics", "radar", "guidance"]
+  roles       = ["radar-sensor", "guidance-computer"]
+
+  message "radar-state" {
+    description = "Doppler radar altitude and horizontal velocity returns"
+
+    field "altitude" {
+      type        = "float32"
+      description = "True radar altitude above lunar terrain"
+      unit        = "ft"
+    }
+
+    field "data-good" {
+      type        = "bool"
+      description = "Radar lock and signal quality flag"
+    }
+
+    field "descent-rate" {
+      type        = "float32"
+      description = "Vertical descent velocity"
+      unit        = "fps"
+    }
+
+    field "forward-velocity" {
+      type        = "float32"
+      description = "Forward terrain-relative speed"
+      unit        = "fps"
+    }
+  }
+}
+
+protocol "rcs-thruster-command" {
+  description = "Jet Driver Electronics firing pulse signals to RCS solenoids"
+  tags        = ["control", "rcs", "actuator"]
+  roles       = ["controller", "thruster-quad"]
+
+  message "jet-fire-pulse" {
+    description = "Discrete pulse command to reaction control thruster valves"
+
+    field "duration" {
+      type        = "uint16"
+      description = "Pulse firing duration"
+      unit        = "ms"
+    }
+
+    field "jet-id" {
+      type        = "uint8"
+      description = "Target thruster quad jet index (1-16)"
+    }
+  }
+}
+
+protocol "saturn-iu-umbilical" {
+  description = "Saturn V Launch Vehicle Digital Computer (LVDC) to CSM guidance handover and abort sensing"
+  tags        = ["guidance", "launch", "abort"]
+  roles       = ["instrument-unit", "csm-eds"]
+
+  message "launch-vehicle-telemetry" {
+    description = "Saturn V propulsion status, vehicle rates, and Emergency Detection System flags"
+
+    field "abort-request" {
+      type        = "bool"
+      description = "Automatic EDS abort initiation signal"
+    }
+
+    field "angular-rate" {
+      type        = "float32"
+      description = "Vehicle body rotational rate"
+      unit        = "deg/s"
+    }
+
+    field "attitude-error" {
+      type        = "float32"
+      description = "Flight trajectory deviation error"
+      unit        = "deg"
+    }
+
+    field "stage-thrust-ok" {
+      type        = "bool"
+      description = "All operating stage engines producing rated thrust"
+    }
+  }
+}
 
 protocol "unified-s-band" {
   description = "2.2 GHz Unified S-band Earth-space telemetry, voice, and ranging"
@@ -15,21 +299,25 @@ protocol "unified-s-band" {
 
   message "downlink-telemetry" {
     description = "Spacecraft state vector, systems health, and cabin telemetry"
-    field "mission-elapsed-time" {
-      type        = "uint32"
-      unit        = "s"
-      description = "MET timestamp from AGC master clock"
-    }
+
     field "cabin-pressure" {
       type        = "float32"
-      unit        = "psia"
       description = "Cabin atmospheric pressure"
+      unit        = "psia"
     }
+
     field "cabin-temp" {
       type        = "float32"
-      unit        = "degF"
       description = "Cabin ambient temperature"
+      unit        = "degF"
     }
+
+    field "mission-elapsed-time" {
+      type        = "uint32"
+      description = "MET timestamp from AGC master clock"
+      unit        = "s"
+    }
+
     field "state-vector" {
       type        = "bytes"
       description = "Position and velocity ephemeris vectors (R, V)"
@@ -38,15 +326,18 @@ protocol "unified-s-band" {
 
   message "uplink-command" {
     description = "Ground command loads, trajectory state updates, and AGC memory writes"
+
+    field "clock-sync" {
+      type        = "uint32"
+      description = "Ground clock synchronization delta"
+      unit        = "ms"
+    }
+
     field "command-word" {
       type        = "uint32"
       description = "Encoded ground command instruction"
     }
-    field "clock-sync" {
-      type        = "uint32"
-      unit        = "ms"
-      description = "Ground clock synchronization delta"
-    }
+
     field "nav-vector-update" {
       type        = "bytes"
       description = "State vector correction uplinked from Houston"
@@ -61,420 +352,18 @@ protocol "vhf-inter-spacecraft" {
 
   message "ranging-data" {
     description = "Lunar orbit CSM-to-LM relative distance and range rate"
-    field "slant-range" {
-      type        = "float32"
-      unit        = "nmi"
-      description = "Direct slant range between CSM and LM"
-    }
+
     field "range-rate" {
       type        = "float32"
-      unit        = "fps"
       description = "Relative velocity along line of sight"
-    }
-  }
-}
-
-protocol "docking-tunnel" {
-  description = "CSM-to-LM mechanical docking probe, drogue, and pressurized transfer tunnel"
-  tags        = ["mechanical", "docking", "pressurized"]
-  roles       = ["active-probe", "passive-drogue"]
-
-  message "tunnel-status" {
-    description = "Docking latch status, pressure equalization, and crew passage hatch"
-    field "latches-locked" {
-      type        = "bool"
-      description = "12 capture latches engaged"
-    }
-    field "differential-pressure" {
-      type        = "float32"
-      unit        = "psi"
-      description = "Delta pressure across CM/LM tunnel hatches"
-    }
-    field "hatch-open" {
-      type        = "bool"
-      description = "Hatch removed for intravehicular transfer"
-    }
-  }
-}
-
-protocol "saturn-iu-umbilical" {
-  description = "Saturn V Launch Vehicle Digital Computer (LVDC) to CSM guidance handover and abort sensing"
-  tags        = ["guidance", "launch", "abort"]
-  roles       = ["instrument-unit", "csm-eds"]
-
-  message "launch-vehicle-telemetry" {
-    description = "Saturn V propulsion status, vehicle rates, and Emergency Detection System flags"
-    field "stage-thrust-ok" {
-      type        = "bool"
-      description = "All operating stage engines producing rated thrust"
-    }
-    field "attitude-error" {
-      type        = "float32"
-      unit        = "deg"
-      description = "Flight trajectory deviation error"
-    }
-    field "angular-rate" {
-      type        = "float32"
-      unit        = "deg/s"
-      description = "Vehicle body rotational rate"
-    }
-    field "abort-request" {
-      type        = "bool"
-      description = "Automatic EDS abort initiation signal"
-    }
-  }
-}
-
-protocol "pgncs-digital-bus" {
-  description = "Primary Guidance, Navigation, and Control System (PGNCS) internal digital bus"
-  tags        = ["avionics", "guidance", "digital"]
-  roles       = ["computer", "peripheral"]
-
-  message "dsky-update" {
-    description = "DSKY 7-segment electroluminescent display update"
-    field "verb" {
-      type        = "uint8"
-      description = "Active two-digit Verb action code"
-    }
-    field "noun" {
-      type        = "uint8"
-      description = "Active two-digit Noun data target code"
-    }
-    field "register-1" {
-      type        = "int32"
-      description = "Upper 5-digit sign/numeric display value"
-    }
-    field "register-2" {
-      type        = "int32"
-      description = "Middle 5-digit sign/numeric display value"
-    }
-    field "register-3" {
-      type        = "int32"
-      description = "Lower 5-digit sign/numeric display value"
-    }
-  }
-
-  message "dsky-key" {
-    description = "DSKY keyboard stroke event"
-    field "key-code" {
-      type        = "uint8"
-      description = "Key matrix scan code (VERB, NOUN, 0-9, ENTR, CLR, PRO)"
-    }
-  }
-}
-
-protocol "imu-gimbal-interface" {
-  description = "Inertial Measurement Unit resolver coupling and torque pulse interface"
-  tags        = ["avionics", "guidance", "imu"]
-  roles       = ["imu-platform", "guidance-computer"]
-
-  message "attitude-angles" {
-    description = "3-axis gimbal resolver angle readings (Outer, Inner, Middle)"
-    field "outer-gimbal" {
-      type        = "float32"
-      unit        = "deg"
-      description = "Outer gimbal angle"
-    }
-    field "inner-gimbal" {
-      type        = "float32"
-      unit        = "deg"
-      description = "Inner gimbal angle"
-    }
-    field "middle-gimbal" {
-      type        = "float32"
-      unit        = "deg"
-      description = "Middle gimbal angle (monitored for gimbal lock)"
-    }
-    field "delta-v-accum" {
-      type        = "float32"
       unit        = "fps"
-      description = "Integrated PIPA accelerometer velocity increment"
     }
-  }
-}
 
-protocol "optical-sighting-bus" {
-  description = "CSM Scanning Telescope and Sextant optical shaft and trunnion resolver link"
-  tags        = ["avionics", "navigation", "optics"]
-  roles       = ["optics-unit", "guidance-computer"]
-
-  message "celestial-sighting" {
-    description = "Star/landmark navigation sighting mark"
-    field "shaft-angle" {
+    field "slant-range" {
       type        = "float32"
-      unit        = "deg"
-      description = "Sextant shaft axis position"
+      description = "Direct slant range between CSM and LM"
+      unit        = "nmi"
     }
-    field "trunnion-angle" {
-      type        = "float32"
-      unit        = "deg"
-      description = "Sextant trunnion axis position"
-    }
-    field "star-id" {
-      type        = "uint8"
-      description = "Catalog star number (e.g. 33 Navi, 37 Nunki)"
-    }
-  }
-}
-
-protocol "rcs-thruster-command" {
-  description = "Jet Driver Electronics firing pulse signals to RCS solenoids"
-  tags        = ["control", "rcs", "actuator"]
-  roles       = ["controller", "thruster-quad"]
-
-  message "jet-fire-pulse" {
-    description = "Discrete pulse command to reaction control thruster valves"
-    field "jet-id" {
-      type        = "uint8"
-      description = "Target thruster quad jet index (1-16)"
-    }
-    field "duration" {
-      type        = "uint16"
-      unit        = "ms"
-      description = "Pulse firing duration"
-    }
-  }
-}
-
-protocol "propellant-feed" {
-  description = "Hypergolic or cryogenic liquid propellant delivery manifold"
-  tags        = ["propulsion", "fluid", "propellant"]
-  roles       = ["tank", "engine"]
-
-  message "propellant-flow" {
-    description = "Propellant mass flow and pressure status"
-    field "pressure" {
-      type        = "float32"
-      unit        = "psia"
-      description = "Manifold fluid delivery pressure"
-    }
-    field "flow-rate" {
-      type        = "float32"
-      unit        = "lb/s"
-      description = "Mass flow rate through propellant valves"
-    }
-    field "valve-open" {
-      type        = "bool"
-      description = "Propellant isolation/injector valve position"
-    }
-  }
-}
-
-protocol "eps-28v-dc" {
-  description = "Main 28V DC electrical power distribution buses"
-  tags        = ["power", "electrical"]
-  roles       = ["power-source", "power-load"]
-
-  message "dc-bus-status" {
-    description = "Voltage and current telemetry on main DC bus"
-    field "voltage" {
-      type        = "float32"
-      unit        = "V"
-      description = "Direct current bus voltage"
-    }
-    field "current" {
-      type        = "float32"
-      unit        = "A"
-      description = "Total load current draw"
-    }
-  }
-}
-
-protocol "cryo-reactant-supply" {
-  description = "Supercritical cryogenic oxygen and hydrogen supply lines"
-  tags        = ["power", "cryo", "fluid"]
-  roles       = ["tank", "consumer"]
-
-  message "reactant-delivery" {
-    description = "Cryogenic reactant flow to fuel cells and ECLSS"
-    field "pressure" {
-      type        = "float32"
-      unit        = "psia"
-      description = "Storage tank pressure"
-    }
-    field "quantity" {
-      type        = "float32"
-      unit        = "lb"
-      description = "Remaining reactant mass"
-    }
-  }
-}
-
-protocol "radar-altimetry" {
-  description = "Landing / rendezvous radar range, range-rate, and altitude beams"
-  tags        = ["avionics", "radar", "guidance"]
-  roles       = ["radar-sensor", "guidance-computer"]
-
-  message "radar-state" {
-    description = "Doppler radar altitude and horizontal velocity returns"
-    field "altitude" {
-      type        = "float32"
-      unit        = "ft"
-      description = "True radar altitude above lunar terrain"
-    }
-    field "forward-velocity" {
-      type        = "float32"
-      unit        = "fps"
-      description = "Forward terrain-relative speed"
-    }
-    field "descent-rate" {
-      type        = "float32"
-      unit        = "fps"
-      description = "Vertical descent velocity"
-    }
-    field "data-good" {
-      type        = "bool"
-      description = "Radar lock and signal quality flag"
-    }
-  }
-}
-
-# ══════════════════════════════════════════════════════════════════════════════
-# 2. Atomic Reusable Building Blocks (Leaf Components)
-# ══════════════════════════════════════════════════════════════════════════════
-
-# ── Ground & Launch Stack Components ───────────────────────────
-
-component "mission-control-center" {
-  description = "Manned Space Flight Network (MSFN) & Houston Mission Control Center (MCC)"
-  icon        = "tower-broadcast"
-  color       = "accent"
-  border      = "dashed"
-  tags        = ["ground", "telemetry"]
-  leaf        = true
-
-  port "csm-ground-link" {
-    description = "Primary 85-foot dish S-band uplink/downlink to CSM"
-    protocol    = "unified-s-band"
-    role        = "ground-station"
-    external    = true
-    tags        = ["rf", "telemetry"]
-  }
-
-  port "lm-ground-link" {
-    description = "Secondary Goldstone/Honeysuckle Creek S-band link to LM"
-    protocol    = "unified-s-band"
-    role        = "ground-station"
-    external    = true
-    tags        = ["rf", "telemetry"]
-  }
-}
-
-component "stage-s-ic" {
-  description = "Saturn V First Stage (5x Rocketdyne F-1 engines, 7.5M lbf thrust, LOX/RP-1)"
-  icon        = "fire"
-  tags        = ["saturn-v", "booster", "propulsion"]
-  leaf        = true
-
-  port "staging-link" {
-    description = "Pyrotechnic stage separation and interstage telemetry"
-    protocol    = "saturn-iu-umbilical"
-    role        = "instrument-unit"
-    external    = true
-    tags        = ["staging"]
-  }
-}
-
-component "stage-s-ii" {
-  description = "Saturn V Second Stage (5x Rocketdyne J-2 engines, 1.15M lbf thrust, LOX/LH2)"
-  icon        = "fire"
-  tags        = ["saturn-v", "propulsion"]
-  leaf        = true
-
-  port "staging-in" {
-    description = "S-IC to S-II separation interface"
-    protocol    = "saturn-iu-umbilical"
-    role        = "csm-eds"
-    external    = true
-    tags        = ["staging"]
-  }
-
-  port "staging-out" {
-    description = "S-II to S-IVB separation interface"
-    protocol    = "saturn-iu-umbilical"
-    role        = "instrument-unit"
-    external    = true
-    tags        = ["staging"]
-  }
-}
-
-component "stage-s-ivb" {
-  description = "Saturn V Third Stage (1x restartable Rocketdyne J-2 engine for Earth orbit & TLI)"
-  icon        = "rocket"
-  tags        = ["saturn-v", "propulsion", "tli"]
-  leaf        = true
-
-  port "staging-in" {
-    description = "S-II to S-IVB separation interface"
-    protocol    = "saturn-iu-umbilical"
-    role        = "csm-eds"
-    external    = true
-    tags        = ["staging"]
-  }
-
-  port "iu-mount" {
-    description = "Structural and electrical mount to Instrument Unit"
-    protocol    = "saturn-iu-umbilical"
-    role        = "csm-eds"
-    external    = true
-    tags        = ["guidance"]
-  }
-}
-
-component "instrument-unit" {
-  description = "Saturn V Instrument Unit (IBM LVDC, ST-124-M3 inertial platform, EDS)"
-  icon        = "microchip"
-  tags        = ["saturn-v", "guidance", "avionics"]
-  leaf        = true
-
-  port "s-ivb-control" {
-    description = "LVDC guidance steering and engine control to S-IVB"
-    protocol    = "saturn-iu-umbilical"
-    role        = "instrument-unit"
-    external    = true
-    tags        = ["guidance"]
-  }
-
-  port "csm-umbilical" {
-    description = "Emergency Detection System (EDS) abort interface to CSM"
-    protocol    = "saturn-iu-umbilical"
-    role        = "instrument-unit"
-    external    = true
-    tags        = ["guidance", "launch"]
-  }
-}
-
-# ── Command Module (CM-107 'Columbia') Components ──────────────
-
-component "cm-cabin-structure" {
-  description = "Crew compartment, astronaut couches, manual hand controllers, and forward hatch"
-  icon        = "users"
-  font        = "italic"
-  tags        = ["csm", "structure", "crew"]
-  leaf        = true
-
-  port "docking-probe" {
-    description = "Active capture probe mechanism and docking ring"
-    protocol    = "docking-tunnel"
-    role        = "active-probe"
-    external    = true
-    tags        = ["mechanical", "docking"]
-  }
-
-  port "manual-rotation" {
-    description = "Rotational Hand Controller (RHC) input to AGC"
-    protocol    = "pgncs-digital-bus"
-    role        = "peripheral"
-    external    = true
-    tags        = ["flight-control"]
-  }
-
-  port "power-in" {
-    description = "28V DC power distribution from SM fuel cells or entry batteries"
-    protocol    = "eps-28v-dc"
-    role        = "power-load"
-    external    = true
-    tags        = ["power"]
   }
 }
 
@@ -489,48 +378,80 @@ component "cm-agc" {
     description = "Digital I/O bus to CM DSKY display and keyboard"
     protocol    = "pgncs-digital-bus"
     role        = "computer"
-    external    = true
     tags        = ["avionics", "ui"]
-  }
-
-  port "imu-bus" {
-    description = "CDU coupling and pulse torquing to CM IMU"
-    protocol    = "imu-gimbal-interface"
-    role        = "guidance-computer"
     external    = true
-    tags        = ["avionics", "guidance"]
-  }
-
-  port "optics-bus" {
-    description = "Optics sextant/telescope mark input"
-    protocol    = "optical-sighting-bus"
-    role        = "guidance-computer"
-    external    = true
-    tags        = ["avionics", "navigation"]
-  }
-
-  port "rcs-commands" {
-    description = "Jet driver firing pulses to CM/SM RCS thruster quads"
-    protocol    = "rcs-thruster-command"
-    role        = "controller"
-    external    = true
-    tags        = ["control", "rcs"]
   }
 
   port "eds-abort-input" {
     description = "Emergency Detection System abort flag from Saturn V IU"
     protocol    = "saturn-iu-umbilical"
     role        = "csm-eds"
-    external    = true
     tags        = ["abort", "launch"]
+    external    = true
+  }
+
+  port "imu-bus" {
+    description = "CDU coupling and pulse torquing to CM IMU"
+    protocol    = "imu-gimbal-interface"
+    role        = "guidance-computer"
+    tags        = ["avionics", "guidance"]
+    external    = true
+  }
+
+  port "optics-bus" {
+    description = "Optics sextant/telescope mark input"
+    protocol    = "optical-sighting-bus"
+    role        = "guidance-computer"
+    tags        = ["avionics", "navigation"]
+    external    = true
   }
 
   port "power-in" {
     description = "Regulated 28V DC power supply input"
     protocol    = "eps-28v-dc"
     role        = "power-load"
-    external    = true
     tags        = ["power"]
+    external    = true
+  }
+
+  port "rcs-commands" {
+    description = "Jet driver firing pulses to CM/SM RCS thruster quads"
+    protocol    = "rcs-thruster-command"
+    role        = "controller"
+    tags        = ["control", "rcs"]
+    external    = true
+  }
+}
+
+component "cm-cabin-structure" {
+  description = "Crew compartment, astronaut couches, manual hand controllers, and forward hatch"
+  icon        = "users"
+  font        = "italic"
+  tags        = ["csm", "structure", "crew"]
+  leaf        = true
+
+  port "docking-probe" {
+    description = "Active capture probe mechanism and docking ring"
+    protocol    = "docking-tunnel"
+    role        = "active-probe"
+    tags        = ["mechanical", "docking"]
+    external    = true
+  }
+
+  port "manual-rotation" {
+    description = "Rotational Hand Controller (RHC) input to AGC"
+    protocol    = "pgncs-digital-bus"
+    role        = "peripheral"
+    tags        = ["flight-control"]
+    external    = true
+  }
+
+  port "power-in" {
+    description = "28V DC power distribution from SM fuel cells or entry batteries"
+    protocol    = "eps-28v-dc"
+    role        = "power-load"
+    tags        = ["power"]
+    external    = true
   }
 }
 
@@ -544,8 +465,8 @@ component "cm-dsky" {
     description = "Digital interface to Apollo Guidance Computer"
     protocol    = "pgncs-digital-bus"
     role        = "peripheral"
-    external    = true
     tags        = ["avionics", "ui"]
+    external    = true
   }
 }
 
@@ -559,8 +480,8 @@ component "cm-imu" {
     description = "Resolver angle feedback and gyro torquing signals to AGC"
     protocol    = "imu-gimbal-interface"
     role        = "imu-platform"
-    external    = true
     tags        = ["guidance"]
+    external    = true
   }
 }
 
@@ -574,8 +495,8 @@ component "cm-optics" {
     description = "Shaft and trunnion angles to AGC on navigational mark"
     protocol    = "optical-sighting-bus"
     role        = "optics-unit"
-    external    = true
     tags        = ["navigation"]
+    external    = true
   }
 }
 
@@ -589,120 +510,139 @@ component "cm-rcs" {
     description = "Solenoid valve driver signals from AGC"
     protocol    = "rcs-thruster-command"
     role        = "thruster-quad"
-    external    = true
     tags        = ["control", "rcs"]
+    external    = true
   }
 }
 
-# ── Service Module (SM-107) Components ─────────────────────────
+component "command-module" {
+  description = "Apollo Command Module (CM-107 'Columbia') Crew Compartment and PGNCS Avionics"
+  icon        = "satellite"
+  color       = "info"
+  tags        = ["csm", "cm", "spacecraft"]
 
-component "sm-sps-propellant-tanks" {
-  description = "Service Propulsion System Aerozine-50 fuel and N2O4 oxidizer storage tanks"
+  instance "agc" { source = "cm-agc" }
+
+  instance "cabin" { source = "cm-cabin-structure" }
+
+  instance "dsky" { source = "cm-dsky" }
+
+  instance "imu" { source = "cm-imu" }
+
+  instance "optics" { source = "cm-optics" }
+
+  instance "rcs" { source = "cm-rcs" }
+
+  connection "agc-to-dsky" {
+    description  = "DSKY display updates and keypad entries"
+    tags         = ["avionics", "ui"]
+    from         = "agc/dsky-bus"
+    to           = "dsky/agc-interface"
+  }
+
+  connection "agc-to-imu" {
+    description  = "IMU resolver angle readouts and gyro torquing"
+    tags         = ["guidance", "imu"]
+    from         = "imu/agc-coupling"
+    to           = "agc/imu-bus"
+  }
+
+  connection "agc-to-optics" {
+    description  = "Sextant and telescope navigational sightings"
+    tags         = ["navigation", "optics"]
+    from         = "optics/agc-sighting"
+    to           = "agc/optics-bus"
+  }
+
+  connection "agc-to-rcs" {
+    description  = "Re-entry attitude control firing pulses"
+    tags         = ["control", "rcs"]
+    from         = "agc/rcs-commands"
+    to           = "rcs/driver-signals"
+  }
+
+  connection "cabin-power-to-agc" {
+    description  = "Cabin electrical bus feed to Apollo Guidance Computer"
+    tags         = ["power"]
+    from         = "cabin/power-in"
+    to           = "agc/power-in"
+  }
+
+  connection "rhc-manual-input" {
+    description  = "Astronaut manual rotational hand controller to AGC"
+    tags         = ["flight-control"]
+    from         = "agc/dsky-bus"
+    to           = "cabin/manual-rotation"
+  }
+}
+
+component "instrument-unit" {
+  description = "Saturn V Instrument Unit (IBM LVDC, ST-124-M3 inertial platform, EDS)"
+  icon        = "microchip"
+  tags        = ["saturn-v", "guidance", "avionics"]
+  leaf        = true
+
+  port "csm-umbilical" {
+    description = "Emergency Detection System (EDS) abort interface to CSM"
+    protocol    = "saturn-iu-umbilical"
+    role        = "instrument-unit"
+    tags        = ["guidance", "launch"]
+    external    = true
+  }
+
+  port "s-ivb-control" {
+    description = "LVDC guidance steering and engine control to S-IVB"
+    protocol    = "saturn-iu-umbilical"
+    role        = "instrument-unit"
+    tags        = ["guidance"]
+    external    = true
+  }
+}
+
+component "lm-aps-propellant-tanks" {
+  description = "Ascent stage hypergolic Aerozine-50 and N2O4 propellant storage tanks"
   icon        = "gas-pump"
-  tags        = ["csm", "sm", "propellant", "tanks"]
+  tags        = ["lm", "ascent", "propellant", "tanks"]
   leaf        = true
 
   port "propellant-out" {
-    description = "Pressurized propellant feed to SPS engine"
+    description = "Direct propellant feed to APS engine"
     protocol    = "propellant-feed"
     role        = "tank"
-    external    = true
     tags        = ["propulsion"]
+    external    = true
   }
 }
 
-component "sm-service-propulsion" {
-  description = "Service Propulsion System (Aerojet AJ10-137 engine, 20,500 lbf, LOI / TEI burns)"
+component "lm-ascent-propulsion" {
+  description = "Ascent Propulsion System (APS - Bell Aerosystems 3,500 lbf fixed-thrust hypergolic engine)"
   icon        = "fire"
-  tags        = ["csm", "sm", "propulsion"]
+  tags        = ["lm", "ascent", "propulsion"]
   leaf        = true
 
   port "propellant-in" {
-    description = "Aerozine-50 and N2O4 hypergolic propellant feed"
+    description = "Aerozine-50 and N2O4 hypergolic fuel feed"
     protocol    = "propellant-feed"
     role        = "engine"
-    external    = true
     tags        = ["propulsion"]
+    external    = true
   }
 }
 
-component "sm-rcs-quads" {
-  description = "Service Module RCS (4x quads of Marquardt R-4D 100-lbf thrusters for translation & attitude)"
-  icon        = "arrows-to-dot"
-  tags        = ["csm", "sm", "rcs"]
+component "lm-batteries" {
+  description = "Silver-Zinc primary batteries (4x descent stage 400 Ah batteries + 2x ascent stage 296 Ah)"
+  icon        = "battery-three-quarters"
+  tags        = ["lm", "eps", "power"]
   leaf        = true
-
-  port "driver-signals" {
-    description = "Firing pulses from Command Module AGC"
-    protocol    = "rcs-thruster-command"
-    role        = "thruster-quad"
-    external    = true
-    tags        = ["control", "rcs"]
-  }
-}
-
-component "sm-fuel-cells" {
-  description = "3x Bacon-type Pratt & Whitney H2-O2 Fuel Cells (28V DC power + potable drinking water)"
-  icon        = "battery-full"
-  tags        = ["csm", "sm", "eps", "power"]
-  leaf        = true
-
-  port "h2-o2-reactant-in" {
-    description = "Supercritical oxygen and hydrogen supply"
-    protocol    = "cryo-reactant-supply"
-    role        = "consumer"
-    external    = true
-    tags        = ["cryo", "power"]
-  }
 
   port "power-out" {
-    description = "Main 28V DC power bus feed to CM and SM systems"
+    description = "Main 28V DC electrical power delivery"
     protocol    = "eps-28v-dc"
     role        = "power-source"
-    external    = true
     tags        = ["power"]
+    external    = true
   }
 }
-
-component "sm-cryogenic-storage" {
-  description = "Cryogenic Gas Storage System (Supercritical liquid O2 tanks and liquid H2 tanks)"
-  icon        = "snowflake"
-  tags        = ["csm", "sm", "cryo", "tanks"]
-  leaf        = true
-
-  port "fuel-cell-supply" {
-    description = "Cryogenic hydrogen and oxygen feed lines to fuel cells"
-    protocol    = "cryo-reactant-supply"
-    role        = "tank"
-    external    = true
-    tags        = ["cryo", "power"]
-  }
-}
-
-component "sm-high-gain-antenna" {
-  description = "Steerable 4-dish S-band high-gain antenna array for lunar distance telemetry & TV"
-  icon        = "satellite-dish"
-  tags        = ["csm", "sm", "rf", "comms"]
-  leaf        = true
-
-  port "rf-ground-link" {
-    description = "Deep Space Network / MSFN ground station link"
-    protocol    = "unified-s-band"
-    role        = "spacecraft-transceiver"
-    external    = true
-    tags        = ["rf", "telemetry"]
-  }
-
-  port "vhf-transceiver" {
-    description = "VHF recovery and Lunar Module ranging transceiver"
-    protocol    = "vhf-inter-spacecraft"
-    role        = "csm-transceiver"
-    external    = true
-    tags        = ["rf", "ranging"]
-  }
-}
-
-# ── Lunar Module Ascent Stage (LM-5 'Eagle') Components ────────
 
 component "lm-cabin" {
   description = "Ascent stage pressurized crew cabin, stand-up astronaut stations, and overhead docking drogue"
@@ -715,16 +655,114 @@ component "lm-cabin" {
     description = "Passive conical docking drogue and overhead transfer hatch"
     protocol    = "docking-tunnel"
     role        = "passive-drogue"
-    external    = true
     tags        = ["mechanical", "docking"]
+    external    = true
   }
 
   port "power-in" {
     description = "28V DC power feed from ascent/descent battery buses"
     protocol    = "eps-28v-dc"
     role        = "power-load"
-    external    = true
     tags        = ["power"]
+    external    = true
+  }
+}
+
+component "lm-comms-subsystem" {
+  description = "LM Communications (Steerable S-band high-gain antenna, omni antennas, and VHF ranging)"
+  icon        = "satellite-dish"
+  tags        = ["lm", "ascent", "rf", "comms"]
+  leaf        = true
+
+  port "s-band-ground" {
+    description = "Unified S-band link to MSFN ground stations"
+    protocol    = "unified-s-band"
+    role        = "spacecraft-transceiver"
+    tags        = ["rf", "telemetry"]
+    external    = true
+  }
+
+  port "vhf-ranging" {
+    description = "VHF ranging transceiver linking to Command Module"
+    protocol    = "vhf-inter-spacecraft"
+    role        = "lm-transceiver"
+    tags        = ["rf", "ranging"]
+    external    = true
+  }
+}
+
+component "lm-descent-propulsion" {
+  description = "Descent Propulsion System (DPS - TRW throttleable 1,050 to 9,850 lbf engine for lunar landing)"
+  icon        = "fire"
+  tags        = ["lm", "descent", "propulsion", "landing"]
+  leaf        = true
+
+  port "propellant-in" {
+    description = "Hypergolic Aerozine-50 and N2O4 propellant supply"
+    protocol    = "propellant-feed"
+    role        = "engine"
+    tags        = ["propulsion"]
+    external    = true
+  }
+}
+
+component "lm-dps-propellant-tanks" {
+  description = "Descent stage propellant tanks (4x large cylindrical Aerozine-50 and N2O4 tanks)"
+  icon        = "gas-pump"
+  tags        = ["lm", "descent", "propellant", "tanks"]
+  leaf        = true
+
+  port "propellant-out" {
+    description = "Manifold feed to throttleable DPS engine"
+    protocol    = "propellant-feed"
+    role        = "tank"
+    tags        = ["propulsion"]
+    external    = true
+  }
+}
+
+component "lm-dsky" {
+  description = "Lunar Module DSKY display and keyboard unit"
+  icon        = "calculator"
+  tags        = ["lm", "ascent", "avionics", "ui"]
+  leaf        = true
+
+  port "lgc-interface" {
+    description = "Digital bus link to LGC"
+    protocol    = "pgncs-digital-bus"
+    role        = "peripheral"
+    tags        = ["avionics", "ui"]
+    external    = true
+  }
+}
+
+component "lm-imu" {
+  description = "LM Primary Guidance IMU (3-gimbal inertial platform)"
+  icon        = "compass"
+  tags        = ["lm", "ascent", "guidance", "imu"]
+  leaf        = true
+
+  port "lgc-coupling" {
+    description = "Gimbal resolver angle signals to LGC"
+    protocol    = "imu-gimbal-interface"
+    role        = "imu-platform"
+    tags        = ["guidance"]
+    external    = true
+  }
+}
+
+component "lm-landing-radar" {
+  description = "Ryan 4-beam Doppler Landing Radar (Continuous-wave velocity and radar altimeter)"
+  icon        = "radar"
+  tags        = ["lm", "descent", "radar", "landing"]
+  leaf        = true
+
+  port "radar-returns" {
+    description = "Altitude and horizontal velocity beam state to LGC"
+    protocol    = "radar-altimetry"
+    role        = "radar-sensor"
+    tags        = ["radar", "landing"]
+    external    = true
   }
 }
 
@@ -739,100 +777,40 @@ component "lm-lgc" {
     description = "Digital I/O to LM DSKY"
     protocol    = "pgncs-digital-bus"
     role        = "computer"
-    external    = true
     tags        = ["avionics", "ui"]
+    external    = true
   }
 
   port "imu-bus" {
     description = "Resolver signals to LM primary IMU"
     protocol    = "imu-gimbal-interface"
     role        = "guidance-computer"
-    external    = true
     tags        = ["guidance"]
+    external    = true
   }
 
   port "landing-radar-input" {
     description = "Doppler altitude and velocity beam returns from landing radar"
     protocol    = "radar-altimetry"
     role        = "guidance-computer"
-    external    = true
     tags        = ["radar", "landing"]
-  }
-
-  port "rcs-commands" {
-    description = "Firing commands to LM ascent stage RCS thruster quads"
-    protocol    = "rcs-thruster-command"
-    role        = "controller"
     external    = true
-    tags        = ["control", "rcs"]
   }
 
   port "power-in" {
     description = "28V DC power supply input"
     protocol    = "eps-28v-dc"
     role        = "power-load"
-    external    = true
     tags        = ["power"]
-  }
-}
-
-component "lm-dsky" {
-  description = "Lunar Module DSKY display and keyboard unit"
-  icon        = "calculator"
-  tags        = ["lm", "ascent", "avionics", "ui"]
-  leaf        = true
-
-  port "lgc-interface" {
-    description = "Digital bus link to LGC"
-    protocol    = "pgncs-digital-bus"
-    role        = "peripheral"
     external    = true
-    tags        = ["avionics", "ui"]
   }
-}
 
-component "lm-imu" {
-  description = "LM Primary Guidance IMU (3-gimbal inertial platform)"
-  icon        = "compass"
-  tags        = ["lm", "ascent", "guidance", "imu"]
-  leaf        = true
-
-  port "lgc-coupling" {
-    description = "Gimbal resolver angle signals to LGC"
-    protocol    = "imu-gimbal-interface"
-    role        = "imu-platform"
+  port "rcs-commands" {
+    description = "Firing commands to LM ascent stage RCS thruster quads"
+    protocol    = "rcs-thruster-command"
+    role        = "controller"
+    tags        = ["control", "rcs"]
     external    = true
-    tags        = ["guidance"]
-  }
-}
-
-component "lm-aps-propellant-tanks" {
-  description = "Ascent stage hypergolic Aerozine-50 and N2O4 propellant storage tanks"
-  icon        = "gas-pump"
-  tags        = ["lm", "ascent", "propellant", "tanks"]
-  leaf        = true
-
-  port "propellant-out" {
-    description = "Direct propellant feed to APS engine"
-    protocol    = "propellant-feed"
-    role        = "tank"
-    external    = true
-    tags        = ["propulsion"]
-  }
-}
-
-component "lm-ascent-propulsion" {
-  description = "Ascent Propulsion System (APS - Bell Aerosystems 3,500 lbf fixed-thrust hypergolic engine)"
-  icon        = "fire"
-  tags        = ["lm", "ascent", "propulsion"]
-  leaf        = true
-
-  port "propellant-in" {
-    description = "Aerozine-50 and N2O4 hypergolic fuel feed"
-    protocol    = "propellant-feed"
-    role        = "engine"
-    external    = true
-    tags        = ["propulsion"]
   }
 }
 
@@ -846,230 +824,8 @@ component "lm-rcs-quads" {
     description = "Firing pulses from LGC jet driver electronics"
     protocol    = "rcs-thruster-command"
     role        = "thruster-quad"
-    external    = true
     tags        = ["control", "rcs"]
-  }
-}
-
-component "lm-comms-subsystem" {
-  description = "LM Communications (Steerable S-band high-gain antenna, omni antennas, and VHF ranging)"
-  icon        = "satellite-dish"
-  tags        = ["lm", "ascent", "rf", "comms"]
-  leaf        = true
-
-  port "s-band-ground" {
-    description = "Unified S-band link to MSFN ground stations"
-    protocol    = "unified-s-band"
-    role        = "spacecraft-transceiver"
     external    = true
-    tags        = ["rf", "telemetry"]
-  }
-
-  port "vhf-ranging" {
-    description = "VHF ranging transceiver linking to Command Module"
-    protocol    = "vhf-inter-spacecraft"
-    role        = "lm-transceiver"
-    external    = true
-    tags        = ["rf", "ranging"]
-  }
-}
-
-# ── Lunar Module Descent Stage (LM-5 'Eagle') Components ───────
-
-component "lm-dps-propellant-tanks" {
-  description = "Descent stage propellant tanks (4x large cylindrical Aerozine-50 and N2O4 tanks)"
-  icon        = "gas-pump"
-  tags        = ["lm", "descent", "propellant", "tanks"]
-  leaf        = true
-
-  port "propellant-out" {
-    description = "Manifold feed to throttleable DPS engine"
-    protocol    = "propellant-feed"
-    role        = "tank"
-    external    = true
-    tags        = ["propulsion"]
-  }
-}
-
-component "lm-descent-propulsion" {
-  description = "Descent Propulsion System (DPS - TRW throttleable 1,050 to 9,850 lbf engine for lunar landing)"
-  icon        = "fire"
-  tags        = ["lm", "descent", "propulsion", "landing"]
-  leaf        = true
-
-  port "propellant-in" {
-    description = "Hypergolic Aerozine-50 and N2O4 propellant supply"
-    protocol    = "propellant-feed"
-    role        = "engine"
-    external    = true
-    tags        = ["propulsion"]
-  }
-}
-
-component "lm-landing-radar" {
-  description = "Ryan 4-beam Doppler Landing Radar (Continuous-wave velocity and radar altimeter)"
-  icon        = "radar"
-  tags        = ["lm", "descent", "radar", "landing"]
-  leaf        = true
-
-  port "radar-returns" {
-    description = "Altitude and horizontal velocity beam state to LGC"
-    protocol    = "radar-altimetry"
-    role        = "radar-sensor"
-    external    = true
-    tags        = ["radar", "landing"]
-  }
-}
-
-component "lm-batteries" {
-  description = "Silver-Zinc primary batteries (4x descent stage 400 Ah batteries + 2x ascent stage 296 Ah)"
-  icon        = "battery-three-quarters"
-  tags        = ["lm", "eps", "power"]
-  leaf        = true
-
-  port "power-out" {
-    description = "Main 28V DC electrical power delivery"
-    protocol    = "eps-28v-dc"
-    role        = "power-source"
-    external    = true
-    tags        = ["power"]
-  }
-}
-
-# ══════════════════════════════════════════════════════════════════════════════
-# 3. Intermediate Subsystem Assemblies (Composed with `source`)
-# ══════════════════════════════════════════════════════════════════════════════
-
-component "saturn-v-stack" {
-  description = "Saturn V Launch Vehicle Stack (S-IC First Stage, S-II Second Stage, S-IVB Third Stage, Instrument Unit)"
-  icon        = "rocket"
-  color       = "primary"
-  tags        = ["saturn-v", "launch-vehicle"]
-  leaf        = false
-
-  instance "s-ic" { source = "stage-s-ic" }
-
-  instance "s-ii" { source = "stage-s-ii" }
-
-  instance "s-ivb" { source = "stage-s-ivb" }
-
-  instance "iu" { source = "instrument-unit" }
-
-  connection "s1-to-s2-staging" {
-    description = "S-IC to S-II staging command and telemetry link"
-    tags        = ["staging"]
-    from        = "s-ic/staging-link"
-    to          = "s-ii/staging-in"
-  }
-
-  connection "s2-to-s3-staging" {
-    description = "S-II to S-IVB staging command link"
-    tags        = ["staging"]
-    from        = "s-ii/staging-out"
-    to          = "s-ivb/staging-in"
-  }
-
-  connection "iu-to-s-ivb-guidance" {
-    description = "LVDC steering commands to S-IVB J-2 gimbal actuators"
-    tags        = ["guidance"]
-    from        = "iu/s-ivb-control"
-    to          = "s-ivb/iu-mount"
-  }
-}
-
-component "command-module" {
-  description = "Apollo Command Module (CM-107 'Columbia') Crew Compartment and PGNCS Avionics"
-  icon        = "satellite"
-  color       = "info"
-  tags        = ["csm", "cm", "spacecraft"]
-  leaf        = false
-
-  instance "cabin" { source = "cm-cabin-structure" }
-
-  instance "agc" { source = "cm-agc" }
-
-  instance "dsky" { source = "cm-dsky" }
-
-  instance "imu" { source = "cm-imu" }
-
-  instance "optics" { source = "cm-optics" }
-
-  instance "rcs" { source = "cm-rcs" }
-
-  connection "agc-to-dsky" {
-    description = "DSKY display updates and keypad entries"
-    tags        = ["avionics", "ui"]
-    from        = "agc/dsky-bus"
-    to          = "dsky/agc-interface"
-  }
-
-  connection "agc-to-imu" {
-    description = "IMU resolver angle readouts and gyro torquing"
-    tags        = ["guidance", "imu"]
-    from        = "imu/agc-coupling"
-    to          = "agc/imu-bus"
-  }
-
-  connection "agc-to-optics" {
-    description = "Sextant and telescope navigational sightings"
-    tags        = ["navigation", "optics"]
-    from        = "optics/agc-sighting"
-    to          = "agc/optics-bus"
-  }
-
-  connection "agc-to-rcs" {
-    description = "Re-entry attitude control firing pulses"
-    tags        = ["control", "rcs"]
-    from        = "agc/rcs-commands"
-    to          = "rcs/driver-signals"
-  }
-
-  connection "rhc-manual-input" {
-    description = "Astronaut manual rotational hand controller to AGC"
-    tags        = ["flight-control"]
-    from        = "agc/dsky-bus"
-    to          = "cabin/manual-rotation"
-  }
-
-  connection "cabin-power-to-agc" {
-    description = "Cabin electrical bus feed to Apollo Guidance Computer"
-    tags        = ["power"]
-    from        = "cabin/power-in"
-    to          = "agc/power-in"
-  }
-}
-
-component "service-module" {
-  description = "Apollo Service Module (SM-107) Propulsion, Fuel Cells, Cryogenics, and High Gain Antenna"
-  icon        = "solar-panel"
-  color       = "secondary"
-  tags        = ["csm", "sm", "spacecraft"]
-  leaf        = false
-
-  instance "sps-tanks" { source = "sm-sps-propellant-tanks" }
-
-  instance "sps" { source = "sm-service-propulsion" }
-
-  instance "rcs-quads" { source = "sm-rcs-quads" }
-
-  instance "fuel-cells" { source = "sm-fuel-cells" }
-
-  instance "cryo-tanks" { source = "sm-cryogenic-storage" }
-
-  instance "hga" { source = "sm-high-gain-antenna" }
-
-  connection "cryo-to-fuel-cells" {
-    description = "Supercritical H2 and O2 feed to fuel cells"
-    tags        = ["cryo", "power"]
-    from        = "cryo-tanks/fuel-cell-supply"
-    to          = "fuel-cells/h2-o2-reactant-in"
-  }
-
-  connection "sps-propellant-feed" {
-    description = "Aerozine-50 and N2O4 feed to SPS main engine"
-    tags        = ["propulsion"]
-    from        = "sps-tanks/propellant-out"
-    to          = "sps/propellant-in"
   }
 }
 
@@ -1078,57 +834,56 @@ component "lunar-module-ascent" {
   icon        = "moon"
   color       = "success"
   tags        = ["lm", "ascent"]
-  leaf        = false
+
+  instance "aps" { source = "lm-ascent-propulsion" }
+
+  instance "aps-tanks" { source = "lm-aps-propellant-tanks" }
 
   instance "cabin" { source = "lm-cabin" }
 
-  instance "lgc" { source = "lm-lgc" }
+  instance "comms" { source = "lm-comms-subsystem" }
 
   instance "dsky" { source = "lm-dsky" }
 
   instance "imu" { source = "lm-imu" }
 
-  instance "aps-tanks" { source = "lm-aps-propellant-tanks" }
-
-  instance "aps" { source = "lm-ascent-propulsion" }
+  instance "lgc" { source = "lm-lgc" }
 
   instance "rcs" { source = "lm-rcs-quads" }
 
-  instance "comms" { source = "lm-comms-subsystem" }
-
-  connection "lgc-to-dsky" {
-    description = "Lunar DSKY readout and keystroke bus"
-    tags        = ["avionics", "ui"]
-    from        = "lgc/dsky-bus"
-    to          = "dsky/lgc-interface"
-  }
-
-  connection "lgc-to-imu" {
-    description = "Primary IMU resolver feedback and gyro torquing"
-    tags        = ["guidance", "imu"]
-    from        = "imu/lgc-coupling"
-    to          = "lgc/imu-bus"
-  }
-
-  connection "lgc-to-rcs" {
-    description = "Ascent stage attitude control thruster firings"
-    tags        = ["control", "rcs"]
-    from        = "lgc/rcs-commands"
-    to          = "rcs/driver-signals"
-  }
-
   connection "aps-propellant-feed" {
-    description = "Ascent propellant feed to APS engine"
-    tags        = ["propulsion"]
-    from        = "aps-tanks/propellant-out"
-    to          = "aps/propellant-in"
+    description  = "Ascent propellant feed to APS engine"
+    tags         = ["propulsion"]
+    from         = "aps-tanks/propellant-out"
+    to           = "aps/propellant-in"
   }
 
   connection "cabin-power-to-lgc" {
-    description = "Cabin power bus distribution to LGC"
-    tags        = ["power"]
-    from        = "cabin/power-in"
-    to          = "lgc/power-in"
+    description  = "Cabin power bus distribution to LGC"
+    tags         = ["power"]
+    from         = "cabin/power-in"
+    to           = "lgc/power-in"
+  }
+
+  connection "lgc-to-dsky" {
+    description  = "Lunar DSKY readout and keystroke bus"
+    tags         = ["avionics", "ui"]
+    from         = "lgc/dsky-bus"
+    to           = "dsky/lgc-interface"
+  }
+
+  connection "lgc-to-imu" {
+    description  = "Primary IMU resolver feedback and gyro torquing"
+    tags         = ["guidance", "imu"]
+    from         = "imu/lgc-coupling"
+    to           = "lgc/imu-bus"
+  }
+
+  connection "lgc-to-rcs" {
+    description  = "Ascent stage attitude control thruster firings"
+    tags         = ["control", "rcs"]
+    from         = "lgc/rcs-commands"
+    to           = "rcs/driver-signals"
   }
 }
 
@@ -1137,38 +892,289 @@ component "lunar-module-descent" {
   icon        = "circle-down"
   color       = "warning"
   tags        = ["lm", "descent"]
-  leaf        = false
-
-  instance "dps-tanks" { source = "lm-dps-propellant-tanks" }
-
-  instance "dps" { source = "lm-descent-propulsion" }
-
-  instance "landing-radar" { source = "lm-landing-radar" }
 
   instance "batteries" { source = "lm-batteries" }
 
+  instance "dps" { source = "lm-descent-propulsion" }
+
+  instance "dps-tanks" { source = "lm-dps-propellant-tanks" }
+
+  instance "landing-radar" { source = "lm-landing-radar" }
+
   connection "dps-propellant-feed" {
-    description = "Descent propellant tanks manifold supply to DPS engine"
-    tags        = ["propulsion", "landing"]
-    from        = "dps-tanks/propellant-out"
-    to          = "dps/propellant-in"
+    description  = "Descent propellant tanks manifold supply to DPS engine"
+    tags         = ["propulsion", "landing"]
+    from         = "dps-tanks/propellant-out"
+    to           = "dps/propellant-in"
   }
 }
 
-# ══════════════════════════════════════════════════════════════════════════════
-# 4. Top-Level System Architecture (`system "apollo-11"`)
-# ══════════════════════════════════════════════════════════════════════════════
+component "mission-control-center" {
+  description = "Manned Space Flight Network (MSFN) & Houston Mission Control Center (MCC)"
+  icon        = "tower-broadcast"
+  color       = "accent"
+  border      = "dashed"
+  tags        = ["ground", "telemetry"]
+  leaf        = true
+
+  port "csm-ground-link" {
+    description = "Primary 85-foot dish S-band uplink/downlink to CSM"
+    protocol    = "unified-s-band"
+    role        = "ground-station"
+    tags        = ["rf", "telemetry"]
+    external    = true
+  }
+
+  port "lm-ground-link" {
+    description = "Secondary Goldstone/Honeysuckle Creek S-band link to LM"
+    protocol    = "unified-s-band"
+    role        = "ground-station"
+    tags        = ["rf", "telemetry"]
+    external    = true
+  }
+}
+
+component "saturn-v-stack" {
+  description = "Saturn V Launch Vehicle Stack (S-IC First Stage, S-II Second Stage, S-IVB Third Stage, Instrument Unit)"
+  icon        = "rocket"
+  color       = "primary"
+  tags        = ["saturn-v", "launch-vehicle"]
+
+  instance "iu" { source = "instrument-unit" }
+
+  instance "s-ic" { source = "stage-s-ic" }
+
+  instance "s-ii" { source = "stage-s-ii" }
+
+  instance "s-ivb" { source = "stage-s-ivb" }
+
+  connection "iu-to-s-ivb-guidance" {
+    description  = "LVDC steering commands to S-IVB J-2 gimbal actuators"
+    tags         = ["guidance"]
+    from         = "iu/s-ivb-control"
+    to           = "s-ivb/iu-mount"
+  }
+
+  connection "s1-to-s2-staging" {
+    description  = "S-IC to S-II staging command and telemetry link"
+    tags         = ["staging"]
+    from         = "s-ic/staging-link"
+    to           = "s-ii/staging-in"
+  }
+
+  connection "s2-to-s3-staging" {
+    description  = "S-II to S-IVB staging command link"
+    tags         = ["staging"]
+    from         = "s-ii/staging-out"
+    to           = "s-ivb/staging-in"
+  }
+}
+
+component "service-module" {
+  description = "Apollo Service Module (SM-107) Propulsion, Fuel Cells, Cryogenics, and High Gain Antenna"
+  icon        = "solar-panel"
+  color       = "secondary"
+  tags        = ["csm", "sm", "spacecraft"]
+
+  instance "cryo-tanks" { source = "sm-cryogenic-storage" }
+
+  instance "fuel-cells" { source = "sm-fuel-cells" }
+
+  instance "hga" { source = "sm-high-gain-antenna" }
+
+  instance "rcs-quads" { source = "sm-rcs-quads" }
+
+  instance "sps" { source = "sm-service-propulsion" }
+
+  instance "sps-tanks" { source = "sm-sps-propellant-tanks" }
+
+  connection "cryo-to-fuel-cells" {
+    description  = "Supercritical H2 and O2 feed to fuel cells"
+    tags         = ["cryo", "power"]
+    from         = "cryo-tanks/fuel-cell-supply"
+    to           = "fuel-cells/h2-o2-reactant-in"
+  }
+
+  connection "sps-propellant-feed" {
+    description  = "Aerozine-50 and N2O4 feed to SPS main engine"
+    tags         = ["propulsion"]
+    from         = "sps-tanks/propellant-out"
+    to           = "sps/propellant-in"
+  }
+}
+
+component "sm-cryogenic-storage" {
+  description = "Cryogenic Gas Storage System (Supercritical liquid O2 tanks and liquid H2 tanks)"
+  icon        = "snowflake"
+  tags        = ["csm", "sm", "cryo", "tanks"]
+  leaf        = true
+
+  port "fuel-cell-supply" {
+    description = "Cryogenic hydrogen and oxygen feed lines to fuel cells"
+    protocol    = "cryo-reactant-supply"
+    role        = "tank"
+    tags        = ["cryo", "power"]
+    external    = true
+  }
+}
+
+component "sm-fuel-cells" {
+  description = "3x Bacon-type Pratt & Whitney H2-O2 Fuel Cells (28V DC power + potable drinking water)"
+  icon        = "battery-full"
+  tags        = ["csm", "sm", "eps", "power"]
+  leaf        = true
+
+  port "h2-o2-reactant-in" {
+    description = "Supercritical oxygen and hydrogen supply"
+    protocol    = "cryo-reactant-supply"
+    role        = "consumer"
+    tags        = ["cryo", "power"]
+    external    = true
+  }
+
+  port "power-out" {
+    description = "Main 28V DC power bus feed to CM and SM systems"
+    protocol    = "eps-28v-dc"
+    role        = "power-source"
+    tags        = ["power"]
+    external    = true
+  }
+}
+
+component "sm-high-gain-antenna" {
+  description = "Steerable 4-dish S-band high-gain antenna array for lunar distance telemetry & TV"
+  icon        = "satellite-dish"
+  tags        = ["csm", "sm", "rf", "comms"]
+  leaf        = true
+
+  port "rf-ground-link" {
+    description = "Deep Space Network / MSFN ground station link"
+    protocol    = "unified-s-band"
+    role        = "spacecraft-transceiver"
+    tags        = ["rf", "telemetry"]
+    external    = true
+  }
+
+  port "vhf-transceiver" {
+    description = "VHF recovery and Lunar Module ranging transceiver"
+    protocol    = "vhf-inter-spacecraft"
+    role        = "csm-transceiver"
+    tags        = ["rf", "ranging"]
+    external    = true
+  }
+}
+
+component "sm-rcs-quads" {
+  description = "Service Module RCS (4x quads of Marquardt R-4D 100-lbf thrusters for translation & attitude)"
+  icon        = "arrows-to-dot"
+  tags        = ["csm", "sm", "rcs"]
+  leaf        = true
+
+  port "driver-signals" {
+    description = "Firing pulses from Command Module AGC"
+    protocol    = "rcs-thruster-command"
+    role        = "thruster-quad"
+    tags        = ["control", "rcs"]
+    external    = true
+  }
+}
+
+component "sm-service-propulsion" {
+  description = "Service Propulsion System (Aerojet AJ10-137 engine, 20,500 lbf, LOI / TEI burns)"
+  icon        = "fire"
+  tags        = ["csm", "sm", "propulsion"]
+  leaf        = true
+
+  port "propellant-in" {
+    description = "Aerozine-50 and N2O4 hypergolic propellant feed"
+    protocol    = "propellant-feed"
+    role        = "engine"
+    tags        = ["propulsion"]
+    external    = true
+  }
+}
+
+component "sm-sps-propellant-tanks" {
+  description = "Service Propulsion System Aerozine-50 fuel and N2O4 oxidizer storage tanks"
+  icon        = "gas-pump"
+  tags        = ["csm", "sm", "propellant", "tanks"]
+  leaf        = true
+
+  port "propellant-out" {
+    description = "Pressurized propellant feed to SPS engine"
+    protocol    = "propellant-feed"
+    role        = "tank"
+    tags        = ["propulsion"]
+    external    = true
+  }
+}
+
+component "stage-s-ic" {
+  description = "Saturn V First Stage (5x Rocketdyne F-1 engines, 7.5M lbf thrust, LOX/RP-1)"
+  icon        = "fire"
+  tags        = ["saturn-v", "booster", "propulsion"]
+  leaf        = true
+
+  port "staging-link" {
+    description = "Pyrotechnic stage separation and interstage telemetry"
+    protocol    = "saturn-iu-umbilical"
+    role        = "instrument-unit"
+    tags        = ["staging"]
+    external    = true
+  }
+}
+
+component "stage-s-ii" {
+  description = "Saturn V Second Stage (5x Rocketdyne J-2 engines, 1.15M lbf thrust, LOX/LH2)"
+  icon        = "fire"
+  tags        = ["saturn-v", "propulsion"]
+  leaf        = true
+
+  port "staging-in" {
+    description = "S-IC to S-II separation interface"
+    protocol    = "saturn-iu-umbilical"
+    role        = "csm-eds"
+    tags        = ["staging"]
+    external    = true
+  }
+
+  port "staging-out" {
+    description = "S-II to S-IVB separation interface"
+    protocol    = "saturn-iu-umbilical"
+    role        = "instrument-unit"
+    tags        = ["staging"]
+    external    = true
+  }
+}
+
+component "stage-s-ivb" {
+  description = "Saturn V Third Stage (1x restartable Rocketdyne J-2 engine for Earth orbit & TLI)"
+  icon        = "rocket"
+  tags        = ["saturn-v", "propulsion", "tli"]
+  leaf        = true
+
+  port "iu-mount" {
+    description = "Structural and electrical mount to Instrument Unit"
+    protocol    = "saturn-iu-umbilical"
+    role        = "csm-eds"
+    tags        = ["guidance"]
+    external    = true
+  }
+
+  port "staging-in" {
+    description = "S-II to S-IVB separation interface"
+    protocol    = "saturn-iu-umbilical"
+    role        = "csm-eds"
+    tags        = ["staging"]
+    external    = true
+  }
+}
 
 system "apollo-11" {
   description = "Apollo 11 Mission Stack (AS-506) - Trans-Lunar, Lunar Landing, and Deep Space Network Architecture"
   tags        = ["apollo", "aerospace", "nasa"]
-  level       = 0
-
-  instance "saturn-v" { source = "saturn-v-stack" }
 
   instance "cm" { source = "command-module" }
-
-  instance "sm" { source = "service-module" }
 
   instance "lm-ascent" { source = "lunar-module-ascent" }
 
@@ -1176,130 +1182,70 @@ system "apollo-11" {
 
   instance "mcc" { source = "mission-control-center" }
 
-  # ── Launch Vehicle to CSM Connections ─────────
+  instance "saturn-v" { source = "saturn-v-stack" }
 
-  connection "launch-vehicle-eds" {
-    description = "Saturn V Instrument Unit to Command Module Emergency Detection System"
-    tags        = ["launch", "guidance", "abort"]
-    from        = "saturn-v/iu/csm-umbilical"
-    to          = "cm/agc/eds-abort-input"
-  }
-
-  # ── CSM Internal Service Connections ──────────
-
-  connection "sm-fuel-cell-power-to-cm" {
-    description = "28V DC main electrical power crossfeed from SM fuel cells to Command Module"
-    tags        = ["power"]
-    from        = "sm/fuel-cells/power-out"
-    to          = "cm/cabin/power-in"
-  }
+  instance "sm" { source = "service-module" }
 
   connection "cm-agc-to-sm-rcs" {
-    description = "Command Module AGC jet driver signals to Service Module RCS quads"
-    tags        = ["control", "rcs"]
-    from        = "cm/agc/rcs-commands"
-    to          = "sm/rcs-quads/driver-signals"
+    description  = "Command Module AGC jet driver signals to Service Module RCS quads"
+    tags         = ["control", "rcs"]
+    from         = "/apollo-11/cm/agc/rcs-commands"
+    to           = "/apollo-11/sm/rcs-quads/driver-signals"
   }
 
-  # ── CSM to Lunar Module Inter-Spacecraft Connections ──
-
   connection "csm-lm-docking-tunnel" {
-    description = "Transposition, docking, and pressurized crew transfer tunnel"
-    tags        = ["docking", "mechanical"]
-    from        = "cm/cabin/docking-probe"
-    to          = "lm-ascent/cabin/docking-drogue"
+    description  = "Transposition, docking, and pressurized crew transfer tunnel"
+    tags         = ["docking", "mechanical"]
+    from         = "/apollo-11/cm/cabin/docking-probe"
+    to           = "/apollo-11/lm-ascent/cabin/docking-drogue"
   }
 
   connection "csm-lm-vhf-ranging" {
-    description = "VHF lunar rendezvous ranging and voice link between Columbia and Eagle"
-    tags        = ["rf", "ranging"]
-    from        = "sm/hga/vhf-transceiver"
-    to          = "lm-ascent/comms/vhf-ranging"
+    description  = "VHF lunar rendezvous ranging and voice link between Columbia and Eagle"
+    tags         = ["rf", "ranging"]
+    from         = "/apollo-11/sm/hga/vhf-transceiver"
+    to           = "/apollo-11/lm-ascent/comms/vhf-ranging"
   }
 
-  # ── Lunar Module Inter-Stage Connections ──────
-
-  connection "lm-landing-radar-to-lgc" {
-    description = "Descent stage landing radar Doppler altitude and velocity feed to LGC"
-    tags        = ["radar", "landing", "guidance"]
-    from        = "lm-descent/landing-radar/radar-returns"
-    to          = "lm-ascent/lgc/landing-radar-input"
+  connection "launch-vehicle-eds" {
+    description  = "Saturn V Instrument Unit to Command Module Emergency Detection System"
+    tags         = ["launch", "guidance", "abort"]
+    from         = "/apollo-11/saturn-v/iu/csm-umbilical"
+    to           = "/apollo-11/cm/agc/eds-abort-input"
   }
 
   connection "lm-descent-battery-power" {
-    description = "Descent stage silver-zinc batteries powering ascent stage cabin systems"
-    tags        = ["power"]
-    from        = "lm-descent/batteries/power-out"
-    to          = "lm-ascent/cabin/power-in"
+    description  = "Descent stage silver-zinc batteries powering ascent stage cabin systems"
+    tags         = ["power"]
+    from         = "/apollo-11/lm-descent/batteries/power-out"
+    to           = "/apollo-11/lm-ascent/cabin/power-in"
   }
 
-  # ── Ground Network (MSFN) Communications ──────
+  connection "lm-landing-radar-to-lgc" {
+    description  = "Descent stage landing radar Doppler altitude and velocity feed to LGC"
+    tags         = ["radar", "landing", "guidance"]
+    from         = "/apollo-11/lm-descent/landing-radar/radar-returns"
+    to           = "/apollo-11/lm-ascent/lgc/landing-radar-input"
+  }
 
   connection "msfn-to-csm-s-band" {
-    description = "Unified S-band deep space communications link between MCC and CSM high-gain antenna"
-    tags        = ["rf", "telemetry"]
-    from        = "mcc/csm-ground-link"
-    to          = "sm/hga/rf-ground-link"
+    description  = "Unified S-band deep space communications link between MCC and CSM high-gain antenna"
+    tags         = ["rf", "telemetry"]
+    from         = "/apollo-11/mcc/csm-ground-link"
+    to           = "/apollo-11/sm/hga/rf-ground-link"
   }
 
   connection "msfn-to-lm-s-band" {
-    description = "Unified S-band communications link between MCC and Lunar Module steerable antenna"
-    tags        = ["rf", "telemetry"]
-    from        = "mcc/lm-ground-link"
-    to          = "lm-ascent/comms/s-band-ground"
+    description  = "Unified S-band communications link between MCC and Lunar Module steerable antenna"
+    tags         = ["rf", "telemetry"]
+    from         = "/apollo-11/mcc/lm-ground-link"
+    to           = "/apollo-11/lm-ascent/comms/s-band-ground"
   }
-}
 
-# ══════════════════════════════════════════════════════════════════════════════
-# 5. Definable Architectural Views
-# ══════════════════════════════════════════════════════════════════════════════
-
-view "mission-overview" {
-  description = "Complete Apollo 11 trans-lunar architecture overview"
-  system      = "apollo-11"
-
-  filter {
-    max_level     = 3
-    show_messages = true
-  }
-}
-
-view "pgncs-guidance-navigation" {
-  description = "Primary Guidance, Navigation, and Control System (PGNCS) loops on CM and LM"
-  system      = "apollo-11"
-
-  filter {
-    include_tags  = ["guidance", "avionics", "imu", "navigation", "ui"]
-    show_messages = true
-  }
-}
-
-view "rf-telemetry-network" {
-  description = "Unified S-band Earth ground network and inter-spacecraft VHF ranging"
-  system      = "apollo-11"
-
-  filter {
-    include_tags  = ["rf", "telemetry", "ranging"]
-    show_messages = true
-  }
-}
-
-view "lunar-landing-stack" {
-  description = "Lunar Module descent, landing radar, and ascent guidance interfaces"
-  system      = "apollo-11"
-
-  filter {
-    include_tags  = ["lm", "landing", "radar", "docking"]
-    show_messages = true
-  }
-}
-
-view "power-and-cryo-distribution" {
-  description = "Cryogenic reactant storage, SM fuel cells, and 28V DC power distribution"
-  system      = "apollo-11"
-
-  filter {
-    include_tags  = ["power", "cryo"]
-    show_messages = false
+  connection "sm-fuel-cell-power-to-cm" {
+    description  = "28V DC main electrical power crossfeed from SM fuel cells to Command Module"
+    tags         = ["power"]
+    from         = "/apollo-11/sm/fuel-cells/power-out"
+    to           = "/apollo-11/cm/cabin/power-in"
   }
 }

--- a/examples/apollo-11/views.hcl
+++ b/examples/apollo-11/views.hcl
@@ -1,0 +1,52 @@
+view "lunar-landing-stack" {
+  description = "Lunar Module descent, landing radar, and ascent guidance interfaces"
+  system      = "apollo-11"
+
+  filter {
+    include_tags  = ["lm", "landing", "radar", "docking"]
+    show_messages = true
+  }
+}
+
+view "main" {
+  system      = "apollo-11"
+}
+
+view "mission-overview" {
+  description = "Complete Apollo 11 trans-lunar architecture overview"
+  system      = "apollo-11"
+
+  filter {
+    max_level     = 3
+    show_messages = true
+  }
+}
+
+view "pgncs-guidance-navigation" {
+  description = "Primary Guidance, Navigation, and Control System (PGNCS) loops on CM and LM"
+  system      = "apollo-11"
+
+  filter {
+    include_tags  = ["guidance", "avionics", "imu", "navigation", "ui"]
+    show_messages = true
+  }
+}
+
+view "power-and-cryo-distribution" {
+  description = "Cryogenic reactant storage, SM fuel cells, and 28V DC power distribution"
+  system      = "apollo-11"
+
+  filter {
+    include_tags  = ["power", "cryo"]
+  }
+}
+
+view "rf-telemetry-network" {
+  description = "Unified S-band Earth ground network and inter-spacecraft VHF ranging"
+  system      = "apollo-11"
+
+  filter {
+    include_tags  = ["rf", "telemetry", "ranging"]
+    show_messages = true
+  }
+}

--- a/examples/drone/system.hcl
+++ b/examples/drone/system.hcl
@@ -1,63 +1,12 @@
-# Drone system model — a single file containing the complete architecture.
-# Two systems: the quadcopter and the pilot ground control station.
-# The "ground-control" system is deliberately less complete — shows
-# in-progress modeling that still compiles cleanly (W001/W004 warnings only).
-
 project {
   name    = "drone-system"
   version = "0.3.0"
   authors = ["rhizz-examples"]
 }
 
-# ── Protocols ─────────────────────────────
-
-protocol "dshot600" {
-  description = "DShot600 digital motor control"
+protocol "analog-video" {
+  description = "Analog composite video"
   roles       = ["provider", "consumer"]
-
-  message "throttle" {
-    description = "Per-motor throttle command"
-    tags        = ["control"]
-
-    field "motor_id" {
-      type        = "uint8"
-      description = "Motor index 1-4"
-    }
-    field "value" {
-      type        = "uint16"
-      description = "Throttle 0-2047"
-    }
-  }
-}
-
-protocol "uart" {
-  description = "UART serial bus"
-  roles       = ["peer"]
-
-  message "nav-pvt" {
-    description = "Navigation position/velocity/time solution"
-    tags        = ["navigation"]
-
-    field "latitude" {
-      type        = "int32"
-      unit        = "deg*1e7"
-      description = "Latitude"
-    }
-    field "longitude" {
-      type        = "int32"
-      unit        = "deg*1e7"
-      description = "Longitude"
-    }
-    field "altitude" {
-      type        = "int32"
-      unit        = "mm"
-      description = "Altitude above MSL"
-    }
-    field "fix_type" {
-      type        = "uint8"
-      description = "GNSS fix type"
-    }
-  }
 }
 
 protocol "crsf" {
@@ -75,8 +24,28 @@ protocol "crsf" {
   }
 }
 
-protocol "spi" {
-  description = "Serial peripheral interface"
+protocol "dshot600" {
+  description = "DShot600 digital motor control"
+  roles       = ["provider", "consumer"]
+
+  message "throttle" {
+    description = "Per-motor throttle command"
+    tags        = ["control"]
+
+    field "motor_id" {
+      type        = "uint8"
+      description = "Motor index 1-4"
+    }
+
+    field "value" {
+      type        = "uint16"
+      description = "Throttle 0-2047"
+    }
+  }
+}
+
+protocol "i2c" {
+  description = "I2C serial sensor bus"
   roles       = ["provider", "consumer"]
 }
 
@@ -85,99 +54,41 @@ protocol "power-dc" {
   roles       = ["provider", "consumer"]
 }
 
-protocol "analog-video" {
-  description = "Analog composite video"
+protocol "spi" {
+  description = "Serial peripheral interface"
   roles       = ["provider", "consumer"]
 }
 
-protocol "i2c" {
-  description = "I2C serial sensor bus"
-  roles       = ["provider", "consumer"]
-}
+protocol "uart" {
+  description = "UART serial bus"
+  roles       = ["peer"]
 
-# ── Component definitions ─────────────────
-# Reusable component definitions declared outside any system.
-# Inside systems (and other definitions) they are referenced via `instance`.
+  message "nav-pvt" {
+    description = "Navigation position/velocity/time solution"
+    tags        = ["navigation"]
 
-component "flight-controller" {
-  description = "Main flight computer"
-  tags        = ["electronics", "compute"]
-  leaf        = false
+    field "altitude" {
+      type        = "int32"
+      description = "Altitude above MSL"
+      unit        = "mm"
+    }
 
-  port "motor-out" {
-    description = "DShot600 motor control output"
-    protocol    = "dshot600"
-    role        = "provider"
-    external    = true
-    tags        = ["motor", "data"]
-  }
+    field "fix_type" {
+      type        = "uint8"
+      description = "GNSS fix type"
+    }
 
-  port "gps-serial" {
-    description = "UART link for GPS data"
-    protocol    = "uart"
-    role        = "peer"
-    external    = true
-    tags        = ["data", "navigation"]
-  }
+    field "latitude" {
+      type        = "int32"
+      description = "Latitude"
+      unit        = "deg*1e7"
+    }
 
-  port "rc-in" {
-    description = "CRSF serial: receiver → FC"
-    protocol    = "crsf"
-    role        = "consumer"
-    external    = true
-    tags        = ["rf", "control"]
-  }
-
-  instance "mcu" {
-    source = "mcu"
-  }
-
-  instance "imu" {
-    source = "imu"
-  }
-
-  instance "barometer" {
-    source = "barometer"
-  }
-
-  connection "spi-imu" {
-    description = "SPI bus: MCU ↔ IMU"
-    tags        = ["data"]
-    from        = "mcu/spi"
-    to          = "imu/spi"
-  }
-
-  connection "i2c-baro" {
-    description = "I2C bus: MCU ↔ barometer"
-    tags        = ["data"]
-    from        = "mcu"
-    to          = "barometer"
-  }
-}
-
-component "mcu" {
-  description = "STM32H7 ARM Cortex-M7"
-  tags        = ["electronics", "compute"]
-  leaf        = true
-
-  port "spi" {
-    description = "SPI master bus"
-    protocol    = "spi"
-    role        = "provider"
-    tags        = ["data"]
-  }
-}
-
-component "imu" {
-  description = "BMI270 6-axis IMU"
-  tags        = ["electronics", "sensor"]
-  leaf        = true
-
-  port "spi" {
-    description = "SPI slave interface"
-    protocol    = "spi"
-    role        = "consumer"
-    tags        = ["data"]
+    field "longitude" {
+      type        = "int32"
+      description = "Longitude"
+      unit        = "deg*1e7"
+    }
   }
 }
 
@@ -187,10 +98,43 @@ component "barometer" {
   leaf        = true
 }
 
+component "battery" {
+  description = "4S 1300mAh LiPo"
+  tags        = ["power"]
+  leaf        = true
+
+  port "power-out" {
+    description = "Main discharge output"
+    protocol    = "power-dc"
+    role        = "provider"
+    tags        = ["power"]
+  }
+}
+
+component "camera" {
+  description = "FPV camera (analog)"
+  tags        = ["electronics", "video"]
+  leaf        = true
+
+  port "video-out" {
+    description = "Analog video output"
+    protocol    = "analog-video"
+    role        = "provider"
+    tags        = ["video"]
+  }
+}
+
 component "esc" {
   description = "4-in-1 ESC board"
   tags        = ["electronics", "power", "motor"]
   leaf        = true
+
+  port "bec-out" {
+    description = "5V BEC regulated output"
+    protocol    = "power-dc"
+    role        = "provider"
+    tags        = ["power"]
+  }
 
   port "motor-in" {
     description = "DShot600 motor control input"
@@ -205,13 +149,61 @@ component "esc" {
     role        = "consumer"
     tags        = ["power"]
   }
+}
 
-  port "bec-out" {
-    description = "5V BEC regulated output"
-    protocol    = "power-dc"
-    role        = "provider"
-    tags        = ["power"]
+component "flight-controller" {
+  description = "Main flight computer"
+  tags        = ["electronics", "compute"]
+
+  port "gps-serial" {
+    description = "UART link for GPS data"
+    protocol    = "uart"
+    role        = "peer"
+    tags        = ["data", "navigation"]
+    external    = true
   }
+
+  port "motor-out" {
+    description = "DShot600 motor control output"
+    protocol    = "dshot600"
+    role        = "provider"
+    tags        = ["motor", "data"]
+    external    = true
+  }
+
+  port "rc-in" {
+    description = "CRSF serial: receiver → FC"
+    protocol    = "crsf"
+    role        = "consumer"
+    tags        = ["rf", "control"]
+    external    = true
+  }
+
+  instance "barometer" { source = "barometer" }
+
+  instance "imu" { source = "imu" }
+
+  instance "mcu" { source = "mcu" }
+
+  connection "i2c-baro" {
+    description  = "I2C bus: MCU ↔ barometer"
+    tags         = ["data"]
+    from         = "mcu"
+    to           = "barometer"
+  }
+
+  connection "spi-imu" {
+    description  = "SPI bus: MCU ↔ IMU"
+    tags         = ["data"]
+    from         = "mcu/spi"
+    to           = "imu/spi"
+  }
+}
+
+component "goggles" {
+  description = "FPV goggles with DVR"
+  tags        = ["electronics", "video"]
+  leaf        = true
 }
 
 component "gps" {
@@ -230,16 +222,33 @@ component "gps" {
   }
 }
 
-component "battery" {
-  description = "4S 1300mAh LiPo"
-  tags        = ["power"]
+component "ground-station-pc" {
+  tags        = ["compute"]
+}
+
+component "imu" {
+  description = "BMI270 6-axis IMU"
+  tags        = ["electronics", "sensor"]
   leaf        = true
 
-  port "power-out" {
-    description = "Main discharge output"
-    protocol    = "power-dc"
+  port "spi" {
+    description = "SPI slave interface"
+    protocol    = "spi"
+    role        = "consumer"
+    tags        = ["data"]
+  }
+}
+
+component "mcu" {
+  description = "STM32H7 ARM Cortex-M7"
+  tags        = ["electronics", "compute"]
+  leaf        = true
+
+  port "spi" {
+    description = "SPI master bus"
+    protocol    = "spi"
     role        = "provider"
-    tags        = ["power"]
+    tags        = ["data"]
   }
 }
 
@@ -256,6 +265,12 @@ component "radio-rx" {
   }
 }
 
+component "transmitter" {
+  description = "ELRS radio transmitter"
+  tags        = ["electronics", "rf"]
+  leaf        = true
+}
+
 component "vtx" {
   description = "5.8GHz video transmitter"
   tags        = ["electronics", "rf", "video"]
@@ -269,156 +284,89 @@ component "vtx" {
   }
 }
 
-component "camera" {
-  description = "FPV camera (analog)"
-  tags        = ["electronics", "video"]
-  leaf        = true
+system "ground-control" {
+  description = "Pilot ground station"
+  tags        = ["hardware", "ground"]
 
-  port "video-out" {
-    description = "Analog video output"
-    protocol    = "analog-video"
-    role        = "provider"
-    tags        = ["video"]
+  instance "goggles" { source = "goggles" }
+
+  instance "ground-station-pc" { source = "ground-station-pc" }
+
+  instance "transmitter" { source = "transmitter" }
+
+  connection "rf-control" {
+    description  = "868MHz control link: TX → drone"
+    tags         = ["rf", "control"]
+    from         = "/ground-control/transmitter"
+    to           = "/ground-control/ground-station-pc"
+  }
+
+  connection "video-downlink" {
+    description  = "5.8GHz analog video reception"
+    tags         = ["video", "rf"]
+    from         = "/ground-control/ground-station-pc"
+    to           = "/ground-control/goggles"
   }
 }
 
-component "transmitter" {
-  description = "ELRS radio transmitter"
-  tags        = ["electronics", "rf"]
-  leaf        = true
-}
-
-component "goggles" {
-  description = "FPV goggles with DVR"
-  tags        = ["electronics", "video"]
-  leaf        = true
-}
-
-# This component is non-leaf but has no children yet → W001
-component "ground-station-pc" {
-  tags = ["compute"]
-  leaf = false
-  # description intentionally missing → W004
-  # children not yet modeled   → W001
-}
-
-# ── Systems ───────────────────────────────
 
 system "quadcopter" {
   description = "Consumer quadcopter drone"
   tags        = ["hardware", "drone"]
-  level       = 0
 
-  # ── Component instances ────────────────────
+  instance "battery" { source = "battery" }
 
-  instance "flight-controller" {
-    source = "flight-controller"
-  }
+  instance "camera" { source = "camera" }
 
-  instance "esc" {
-    source = "esc"
-  }
+  instance "esc" { source = "esc" }
 
-  instance "gps" {
-    source = "gps"
-  }
+  instance "flight-controller" { source = "flight-controller" }
 
-  instance "battery" {
-    source = "battery"
-  }
+  instance "gps" { source = "gps" }
 
-  instance "radio-rx" {
-    source = "radio-rx"
-  }
+  instance "radio-rx" { source = "radio-rx" }
 
-  instance "vtx" {
-    source = "vtx"
-  }
-
-  instance "camera" {
-    source = "camera"
-  }
-
-  # ── Connections ────────────────────────────
-
-  connection "motor-control" {
-    description = "DShot600 motor signals"
-    tags        = ["motor", "data"]
-    from        = "flight-controller/motor-out"
-    to          = "esc/motor-in"
-  }
+  instance "vtx" { source = "vtx" }
 
   connection "gps-serial" {
-    description = "UART link: FC ↔ GPS"
-    tags        = ["data", "navigation"]
-    from        = "flight-controller/gps-serial"
-    to          = "gps/serial"
+    description  = "UART link: FC ↔ GPS"
+    tags         = ["data", "navigation"]
+    from         = "/quadcopter/flight-controller/gps-serial"
+    to           = "/quadcopter/gps/serial"
   }
 
-  connection "rc-link" {
-    description = "CRSF serial: receiver → FC"
-    tags        = ["rf", "control"]
-    from        = "radio-rx/crsf"
-    to          = "flight-controller/rc-in"
-  }
-
-  connection "power-main" {
-    description = "Battery → ESC main power"
-    tags        = ["power"]
-    from        = "battery/power-out"
-    to          = "esc/power-in"
+  connection "motor-control" {
+    description  = "DShot600 motor signals"
+    tags         = ["motor", "data"]
+    from         = "/quadcopter/flight-controller/motor-out"
+    to           = "/quadcopter/esc/motor-in"
   }
 
   connection "power-bec" {
-    description = "ESC 5V BEC → flight controller"
-    tags        = ["power"]
-    from        = "esc/bec-out"
-    to          = "flight-controller"
+    description  = "ESC 5V BEC → flight controller"
+    tags         = ["power"]
+    from         = "/quadcopter/esc/bec-out"
+    to           = "/quadcopter/flight-controller"
+  }
+
+  connection "power-main" {
+    description  = "Battery → ESC main power"
+    tags         = ["power"]
+    from         = "/quadcopter/battery/power-out"
+    to           = "/quadcopter/esc/power-in"
+  }
+
+  connection "rc-link" {
+    description  = "CRSF serial: receiver → FC"
+    tags         = ["rf", "control"]
+    from         = "/quadcopter/radio-rx/crsf"
+    to           = "/quadcopter/flight-controller/rc-in"
   }
 
   connection "video-feed" {
-    description = "Analog video: camera → VTX"
-    tags        = ["video"]
-    from        = "camera/video-out"
-    to          = "vtx/video-in"
-  }
-}
-
-# ════════════════════════════════════════════
-# Ground control — intentionally incomplete.
-# Shows that a system can be a work-in-progress:
-# non-leaf components without children trigger W001,
-# missing descriptions trigger W004, but no errors.
-# ════════════════════════════════════════════
-
-system "ground-control" {
-  description = "Pilot ground station"
-  tags        = ["hardware", "ground"]
-  level       = 0
-
-  instance "transmitter" {
-    source = "transmitter"
-  }
-
-  instance "goggles" {
-    source = "goggles"
-  }
-
-  instance "ground-station-pc" {
-    source = "ground-station-pc"
-  }
-
-  connection "rf-control" {
-    description = "868MHz control link: TX → drone"
-    tags        = ["rf", "control"]
-    from        = "transmitter"
-    to          = "ground-station-pc"
-  }
-
-  connection "video-downlink" {
-    description = "5.8GHz analog video reception"
-    tags        = ["video", "rf"]
-    from        = "ground-station-pc"
-    to          = "goggles"
+    description  = "Analog video: camera → VTX"
+    tags         = ["video"]
+    from         = "/quadcopter/camera/video-out"
+    to           = "/quadcopter/vtx/video-in"
   }
 }

--- a/examples/drone/views.hcl
+++ b/examples/drone/views.hcl
@@ -3,17 +3,7 @@ view "drone-overview" {
   system      = "quadcopter"
 
   filter {
-    max_level = 1
-  }
-}
-
-view "power-paths" {
-  description = "Power distribution only"
-  system      = "quadcopter"
-
-  filter {
-    include_tags  = ["power"]
-    show_messages = false
+    max_level     = 1
   }
 }
 
@@ -22,8 +12,8 @@ view "fc-internals" {
   system      = "quadcopter"
 
   filter {
-    components = ["flight-controller"]
-    max_level  = 3
+    max_level     = 3
+    components    = ["flight-controller"]
   }
 }
 
@@ -32,6 +22,19 @@ view "ground-station" {
   system      = "ground-control"
 
   filter {
-    max_level = 1
+    max_level     = 1
+  }
+}
+
+view "main" {
+  system      = "ground-control"
+}
+
+view "power-paths" {
+  description = "Power distribution only"
+  system      = "quadcopter"
+
+  filter {
+    include_tags  = ["power"]
   }
 }

--- a/examples/single-file/system.hcl
+++ b/examples/single-file/system.hcl
@@ -4,16 +4,20 @@ project {
   authors = ["rhizz-examples"]
 }
 
-# ── Protocols ─────────────────────────────
-
 protocol "i2c" {
   description = "I2C sensor communication bus"
   roles       = ["provider", "consumer"]
 
   message "reading" {
     description = "Temperature and humidity measurement"
-    field "celsius"  { type = "float32" }
-    field "humidity" { type = "float32" }
+
+    field "celsius" {
+      type        = "float32"
+    }
+
+    field "humidity" {
+      type        = "float32"
+    }
   }
 }
 
@@ -23,50 +27,18 @@ protocol "mqtt" {
 
   message "telemetry" {
     description = "Environmental telemetry payload"
-    field "celsius"   { type = "float32" }
-    field "humidity"  { type = "float32" }
-    field "timestamp" { type = "uint64"  }
-  }
-}
 
-# ── Top-level Reusable Components ─────────
+    field "celsius" {
+      type        = "float32"
+    }
 
-# Reusable top-level component — imported into the system via source = "temp-sensor".
-component "temp-sensor" {
-  description = "BME280 I2C temperature and humidity sensor"
-  icon        = "temperature-half"
-  tags        = ["sensor", "data"]
-  leaf        = true
+    field "humidity" {
+      type        = "float32"
+    }
 
-  port "i2c" {
-    description = "I2C data output"
-    protocol    = "i2c"
-    role        = "provider"
-    external    = true
-    tags        = ["data"]
-  }
-}
-
-component "controller" {
-  description = "ARM Cortex-M4 processing hub"
-  icon        = "microchip"
-  tags        = ["compute", "data"]
-  leaf        = true
-
-  port "i2c-in" {
-    description = "I2C bus to sensor"
-    protocol    = "i2c"
-    role        = "consumer"
-    external    = true
-    tags        = ["data"]
-  }
-
-  port "mqtt-out" {
-    description = "Outbound MQTT telemetry"
-    protocol    = "mqtt"
-    role        = "provider"
-    external    = true
-    tags        = ["data", "cloud"]
+    field "timestamp" {
+      type        = "uint64"
+    }
   }
 }
 
@@ -80,61 +52,70 @@ component "broker" {
     description = "Inbound MQTT telemetry"
     protocol    = "mqtt"
     role        = "consumer"
-    external    = true
     tags        = ["data", "cloud"]
+    external    = true
   }
 }
 
-# ── System Definition ─────────────────────
+component "controller" {
+  description = "ARM Cortex-M4 processing hub"
+  icon        = "microchip"
+  tags        = ["compute", "data"]
+  leaf        = true
+
+  port "i2c-in" {
+    description = "I2C bus to sensor"
+    protocol    = "i2c"
+    role        = "consumer"
+    tags        = ["data"]
+    external    = true
+  }
+
+  port "mqtt-out" {
+    description = "Outbound MQTT telemetry"
+    protocol    = "mqtt"
+    role        = "provider"
+    tags        = ["data", "cloud"]
+    external    = true
+  }
+}
+
+component "temp-sensor" {
+  description = "BME280 I2C temperature and humidity sensor"
+  icon        = "temperature-half"
+  tags        = ["sensor", "data"]
+  leaf        = true
+
+  port "i2c" {
+    description = "I2C data output"
+    protocol    = "i2c"
+    role        = "provider"
+    tags        = ["data"]
+    external    = true
+  }
+}
 
 system "home-monitor" {
   description = "Smart home environmental monitoring node"
   tags        = ["iot", "data"]
-  level       = 0
 
-  instance "sensor" {
-    source = "temp-sensor"
-  }
+  instance "broker" { source = "broker" }
 
-  instance "controller" {
-    source = "controller"
-  }
+  instance "controller" { source = "controller" }
 
-  instance "broker" {
-    source = "broker"
-  }
+  instance "sensor" { source = "temp-sensor" }
 
   connection "read-sensor" {
-    description = "I2C acquisition from sensor to controller"
-    tags        = ["data"]
-    from        = "sensor/i2c"
-    to          = "controller/i2c-in"
+    description  = "I2C acquisition from sensor to controller"
+    tags         = ["data"]
+    from         = "/home-monitor/sensor/i2c"
+    to           = "/home-monitor/controller/i2c-in"
   }
 
   connection "send-telemetry" {
-    description = "MQTT upload from controller to cloud broker"
-    tags        = ["data", "cloud"]
-    from        = "controller/mqtt-out"
-    to          = "broker/mqtt-in"
-  }
-}
-
-view "overview" {
-  description = "Full home-monitor system architecture"
-  system      = "home-monitor"
-
-  filter {
-    max_level     = 2
-    show_messages = true
-  }
-}
-
-view "cloud-path" {
-  description = "Cloud-facing data path only"
-  system      = "home-monitor"
-
-  filter {
-    include_tags  = ["cloud"]
-    show_messages = false
+    description  = "MQTT upload from controller to cloud broker"
+    tags         = ["data", "cloud"]
+    from         = "/home-monitor/controller/mqtt-out"
+    to           = "/home-monitor/broker/mqtt-in"
   }
 }

--- a/examples/single-file/views.hcl
+++ b/examples/single-file/views.hcl
@@ -1,0 +1,18 @@
+view "cloud-path" {
+  description = "Cloud-facing data path only"
+  system      = "home-monitor"
+
+  filter {
+    include_tags  = ["cloud"]
+  }
+}
+
+view "overview" {
+  description = "Full home-monitor system architecture"
+  system      = "home-monitor"
+
+  filter {
+    max_level     = 2
+    show_messages = true
+  }
+}

--- a/examples/social-media/system.hcl
+++ b/examples/social-media/system.hcl
@@ -1,18 +1,18 @@
-# BuzzVid — a simple short-video platform (TikTok clone).
-#
-# Demonstrates:
-#  - Software component decomposition (backend broken into services)
-#  - Reusable protocol definitions with structured message schemas
-#  - Port/connection model with typed and untyped endpoints
-#  - Leaf vs non-leaf at the software level
-
 project {
   name    = "buzzvid"
   version = "0.3.0"
   authors = ["rhizz-examples"]
 }
 
-# ── Protocols ─────────────────────────────
+protocol "grpc" {
+  description = "Internal gRPC microservice communication"
+  roles       = ["provider", "consumer"]
+}
+
+protocol "hls" {
+  description = "HLS video streaming"
+  roles       = ["provider", "consumer"]
+}
 
 protocol "https" {
   description = "HTTP REST API"
@@ -26,6 +26,7 @@ protocol "https" {
       type        = "string"
       description = "Pagination cursor"
     }
+
     field "feed_type" {
       type        = "string"
       description = "for_you | following"
@@ -36,35 +37,21 @@ protocol "https" {
     description = "Initiate video upload"
     tags        = ["api", "video"]
 
+    field "chunk_size" {
+      type        = "uint32"
+      description = "Upload chunk size"
+      unit        = "bytes"
+    }
+
     field "title" {
       type        = "string"
       description = "Video title"
     }
-    field "chunk_size" {
-      type        = "uint32"
-      unit        = "bytes"
-      description = "Upload chunk size"
-    }
   }
-}
-
-protocol "hls" {
-  description = "HLS video streaming"
-  roles       = ["provider", "consumer"]
 }
 
 protocol "push" {
   description = "Push notifications"
-  roles       = ["provider", "consumer"]
-}
-
-protocol "grpc" {
-  description = "Internal gRPC microservice communication"
-  roles       = ["provider", "consumer"]
-}
-
-protocol "sql" {
-  description = "SQL relational database protocol"
   roles       = ["provider", "consumer"]
 }
 
@@ -73,65 +60,9 @@ protocol "s3" {
   roles       = ["provider", "consumer"]
 }
 
-# ── Component definitions ─────────────────
-
-component "mobile-app" {
-  description = "iOS/Android client application"
-  tags        = ["client", "mobile"]
-  leaf        = false
-
-  port "api" {
-    description = "Client-side API endpoint"
-    protocol    = "https"
-    role        = "consumer"
-    external    = true
-    tags        = ["network", "api"]
-  }
-
-  port "stream-in" {
-    description = "HLS/DASH video stream input"
-    protocol    = "hls"
-    role        = "consumer"
-    external    = true
-    tags        = ["video", "network"]
-  }
-
-  port "push-in" {
-    description = "Push notification receiver"
-    protocol    = "push"
-    role        = "consumer"
-    external    = true
-    tags        = ["notification"]
-  }
-
-  instance "video-player" { source = "video-player" }
-  instance "video-recorder" { source = "video-recorder" }
-  instance "feed-ui" { source = "feed-ui" }
-
-  connection "playback" {
-    description = "Feed UI requests playback from player"
-    from        = "feed-ui"
-    to          = "video-player"
-    tags        = ["client"]
-  }
-}
-
-component "video-player" {
-  description = "Adaptive bitrate video player"
-  tags        = ["client", "video"]
-  leaf        = true
-}
-
-component "video-recorder" {
-  description = "Camera capture + filters + upload"
-  tags        = ["client", "video"]
-  leaf        = true
-}
-
-component "feed-ui" {
-  description = "Scrollable video feed (For-You / Following)"
-  tags        = ["client", "ui"]
-  leaf        = true
+protocol "sql" {
+  description = "SQL relational database protocol"
+  roles       = ["provider", "consumer"]
 }
 
 component "api-gateway" {
@@ -139,45 +70,30 @@ component "api-gateway" {
   tags        = ["backend", "infra"]
   leaf        = true
 
-  port "public" {
-    description = "Public-facing API endpoint"
-    protocol    = "https"
-    role        = "provider"
-    tags        = ["network", "api"]
-  }
-
   port "internal" {
     description = "Internal RPC to backend"
     protocol    = "grpc"
     role        = "consumer"
     tags        = ["network", "internal"]
   }
+
+  port "public" {
+    description = "Public-facing API endpoint"
+    protocol    = "https"
+    role        = "provider"
+    tags        = ["network", "api"]
+  }
 }
 
 component "backend" {
   description = "Server-side services"
   tags        = ["backend"]
-  leaf        = false
-
-  port "rpc" {
-    description = "Internal RPC endpoint"
-    protocol    = "grpc"
-    role        = "provider"
-    tags        = ["network", "internal"]
-  }
 
   port "db" {
     description = "Database connection pool"
     protocol    = "sql"
     role        = "consumer"
     tags        = ["data"]
-  }
-
-  port "storage" {
-    description = "Object storage client"
-    protocol    = "s3"
-    role        = "consumer"
-    tags        = ["video", "data"]
   }
 
   port "push-out" {
@@ -187,49 +103,41 @@ component "backend" {
     tags        = ["notification"]
   }
 
-  instance "user-service" { source = "user-service" }
-  instance "video-service" { source = "video-service" }
+  port "rpc" {
+    description = "Internal RPC endpoint"
+    protocol    = "grpc"
+    role        = "provider"
+    tags        = ["network", "internal"]
+  }
+
+  port "storage" {
+    description = "Object storage client"
+    protocol    = "s3"
+    role        = "consumer"
+    tags        = ["video", "data"]
+  }
+
   instance "feed-service" { source = "feed-service" }
+
   instance "recommendation-engine" { source = "recommendation-engine" }
 
+  instance "user-service" { source = "user-service" }
+
+  instance "video-service" { source = "video-service" }
+
   connection "rec-to-feed" {
-    description = "Recommendation scores fed into feed assembly"
-    from        = "recommendation-engine"
-    to          = "feed-service"
-    tags        = ["data"]
+    description  = "Recommendation scores fed into feed assembly"
+    tags         = ["data"]
+    from         = "recommendation-engine"
+    to           = "feed-service"
   }
 
   connection "user-to-feed" {
-    description = "Follow graph lookup for Following tab"
-    from        = "feed-service"
-    to          = "user-service"
-    tags        = ["data"]
+    description  = "Follow graph lookup for Following tab"
+    tags         = ["data"]
+    from         = "feed-service"
+    to           = "user-service"
   }
-}
-
-component "user-service" {
-  description = "Accounts, profiles, follow graph"
-  tags        = ["backend", "data"]
-  leaf        = true
-}
-
-component "video-service" {
-  description = "Upload processing, transcoding, storage"
-  tags        = ["backend", "video"]
-  leaf        = true
-}
-
-component "feed-service" {
-  description = "Feed assembly from recommendation + follow graph"
-  tags        = ["backend", "data"]
-  leaf        = true
-}
-
-# Non-leaf with no children → W001 (work in progress)
-component "recommendation-engine" {
-  description = "ML-based video ranking"
-  tags        = ["backend", "ml"]
-  leaf        = false
 }
 
 component "cdn" {
@@ -265,6 +173,60 @@ component "database" {
   }
 }
 
+component "feed-service" {
+  description = "Feed assembly from recommendation + follow graph"
+  tags        = ["backend", "data"]
+  leaf        = true
+}
+
+component "feed-ui" {
+  description = "Scrollable video feed (For-You / Following)"
+  tags        = ["client", "ui"]
+  leaf        = true
+}
+
+component "mobile-app" {
+  description = "iOS/Android client application"
+  tags        = ["client", "mobile"]
+
+  port "api" {
+    description = "Client-side API endpoint"
+    protocol    = "https"
+    role        = "consumer"
+    tags        = ["network", "api"]
+    external    = true
+  }
+
+  port "push-in" {
+    description = "Push notification receiver"
+    protocol    = "push"
+    role        = "consumer"
+    tags        = ["notification"]
+    external    = true
+  }
+
+  port "stream-in" {
+    description = "HLS/DASH video stream input"
+    protocol    = "hls"
+    role        = "consumer"
+    tags        = ["video", "network"]
+    external    = true
+  }
+
+  instance "feed-ui" { source = "feed-ui" }
+
+  instance "video-player" { source = "video-player" }
+
+  instance "video-recorder" { source = "video-recorder" }
+
+  connection "playback" {
+    description  = "Feed UI requests playback from player"
+    tags         = ["client"]
+    from         = "feed-ui"
+    to           = "video-player"
+  }
+}
+
 component "object-store" {
   description = "S3-compatible blob storage for raw + transcoded video"
   tags        = ["infra", "video"]
@@ -278,68 +240,97 @@ component "object-store" {
   }
 }
 
-# ── System ────────────────────────────────
+component "recommendation-engine" {
+  description = "ML-based video ranking"
+  tags        = ["backend", "ml"]
+}
+
+component "user-service" {
+  description = "Accounts, profiles, follow graph"
+  tags        = ["backend", "data"]
+  leaf        = true
+}
+
+component "video-player" {
+  description = "Adaptive bitrate video player"
+  tags        = ["client", "video"]
+  leaf        = true
+}
+
+component "video-recorder" {
+  description = "Camera capture + filters + upload"
+  tags        = ["client", "video"]
+  leaf        = true
+}
+
+component "video-service" {
+  description = "Upload processing, transcoding, storage"
+  tags        = ["backend", "video"]
+  leaf        = true
+}
 
 system "buzzvid" {
   description = "Short-video social media platform"
   tags        = ["software", "web"]
-  level       = 0
+
+  instance "api-gateway" { source = "api-gateway" }
+
+  instance "backend" { source = "backend" }
+
+  instance "cdn" { source = "cdn" }
+
+  instance "database" { source = "database" }
 
   instance "mobile-app" { source = "mobile-app" }
-  instance "api-gateway" { source = "api-gateway" }
-  instance "backend" { source = "backend" }
-  instance "cdn" { source = "cdn" }
-  instance "database" { source = "database" }
+
   instance "object-store" { source = "object-store" }
 
-  # ── Top-level connections ──────────────────
-
-  connection "client-api" {
-    description = "HTTPS REST/gRPC: mobile app ↔ API gateway"
-    tags        = ["network", "api"]
-    from        = "mobile-app/api"
-    to          = "api-gateway/public"
-  }
-
-  connection "gateway-to-backend" {
-    description = "Internal RPC: gateway → backend services"
-    tags        = ["network", "internal"]
-    from        = "api-gateway/internal"
-    to          = "backend/rpc"
-  }
-
   connection "backend-to-db" {
-    description = "SQL queries: backend → database"
-    tags        = ["data"]
-    from        = "backend/db"
-    to          = "database/sql"
+    description  = "SQL queries: backend → database"
+    tags         = ["data"]
+    from         = "/buzzvid/backend/db"
+    to           = "/buzzvid/database/sql"
   }
 
   connection "backend-to-storage" {
-    description = "Object put/get: video service → blob store"
-    tags        = ["video", "data"]
-    from        = "backend/storage"
-    to          = "object-store/s3"
+    description  = "Object put/get: video service → blob store"
+    tags         = ["video", "data"]
+    from         = "/buzzvid/backend/storage"
+    to           = "/buzzvid/object-store/s3"
   }
 
   connection "cdn-origin" {
-    description = "CDN pulls transcoded segments from object store"
-    tags        = ["video", "infra"]
-    from        = "cdn/origin"
-    to          = "object-store/s3"
+    description  = "CDN pulls transcoded segments from object store"
+    tags         = ["video", "infra"]
+    from         = "/buzzvid/cdn/origin"
+    to           = "/buzzvid/object-store/s3"
+  }
+
+  connection "client-api" {
+    description  = "HTTPS REST/gRPC: mobile app ↔ API gateway"
+    tags         = ["network", "api"]
+    from         = "/buzzvid/mobile-app/api"
+    to           = "/buzzvid/api-gateway/public"
   }
 
   connection "client-streaming" {
-    description = "HLS/DASH video streaming: CDN → mobile app"
-    tags        = ["video", "network"]
-    from        = "cdn/stream-out"
-    to          = "mobile-app/stream-in"
+    description  = "HLS/DASH video streaming: CDN → mobile app"
+    tags         = ["video", "network"]
+    from         = "/buzzvid/cdn/stream-out"
+    to           = "/buzzvid/mobile-app/stream-in"
+  }
+
+  connection "gateway-to-backend" {
+    description  = "Internal RPC: gateway → backend services"
+    tags         = ["network", "internal"]
+    from         = "/buzzvid/api-gateway/internal"
+    to           = "/buzzvid/backend/rpc"
   }
 
   connection "push-notify" {
-    description = "Push notifications: backend → mobile app"
-    tags        = ["notification"]
-    from        = "backend/push-out"
-    to          = "mobile-app/push-in"
+    description  = "Push notifications: backend → mobile app"
+    tags         = ["notification"]
+    from         = "/buzzvid/backend/push-out"
+    to           = "/buzzvid/mobile-app/push-in"
   }
 }

--- a/examples/social-media/views.hcl
+++ b/examples/social-media/views.hcl
@@ -1,19 +1,19 @@
-view "full-platform" {
-  description = "Complete BuzzVid platform overview"
-  system      = "buzzvid"
-
-  filter {
-    max_level = 1
-  }
-}
-
 view "backend-services" {
   description = "Backend service decomposition"
   system      = "buzzvid"
 
   filter {
-    components = ["backend"]
-    max_level  = 3
+    max_level     = 3
+    components    = ["backend"]
+  }
+}
+
+view "full-platform" {
+  description = "Complete BuzzVid platform overview"
+  system      = "buzzvid"
+
+  filter {
+    max_level     = 1
   }
 }
 
@@ -23,6 +23,5 @@ view "video-pipeline" {
 
   filter {
     include_tags  = ["video"]
-    show_messages = false
   }
 }

--- a/examples/software-house/system.hcl
+++ b/examples/software-house/system.hcl
@@ -1,28 +1,64 @@
-# Acme Software Ltd — organizational modeling with rhizz.
-#
-# Demonstrates that rhizz is not limited to hardware or software systems.
-# Here departments are components and business processes are connections.
-#
-# Shows:
-#  - Organizational decomposition (departments → teams)
-#  - Process modeling via connections with port-based message payloads
-#  - Mixed completeness: QA is fully decomposed, Sales is a leaf,
-#    Operations is non-leaf with no children yet (W001)
-# Acme Software — an organizational architecture model of a software house.
-#
-# Demonstrates:
-#  - Non-technical architecture modeling (people/teams/departments)
-#  - Multi-level hierarchy (software-house → department → team)
-#  - Ports and connections used to model communication channels and handoffs
-#  - Protocol definitions describing team communication schemas
-
 project {
   name    = "acme-software"
   version = "0.3.0"
   authors = ["rhizz-examples"]
 }
 
-# ── Protocols ─────────────────────────────
+protocol "agile" {
+  description = "Agile sprint management"
+  roles       = ["provider", "consumer"]
+
+  message "sprint-backlog" {
+    description = "Prioritized list of stories for the sprint"
+    tags        = ["agile"]
+
+    field "capacity" {
+      type        = "uint8"
+      description = "Team capacity"
+      unit        = "points"
+    }
+
+    field "sprint_id" {
+      type        = "string"
+      description = "Sprint identifier"
+    }
+
+    field "stories" {
+      type        = "string[]"
+      description = "Ordered story IDs"
+    }
+  }
+}
+
+protocol "cicd" {
+  description = "Continuous integration and deployment"
+  roles       = ["provider", "consumer"]
+}
+
+protocol "design" {
+  description = "UI/UX design spec delivery"
+  roles       = ["provider", "consumer"]
+
+  message "design-spec" {
+    description = "Figma link + acceptance criteria"
+    tags        = ["process"]
+
+    field "feature_id" {
+      type        = "string"
+      description = "Feature tracker ID"
+    }
+
+    field "figma_url" {
+      type        = "string"
+      description = "Design file URL"
+    }
+  }
+}
+
+protocol "feedback" {
+  description = "Customer feedback stream"
+  roles       = ["provider", "consumer"]
+}
 
 protocol "pr-review" {
   description = "Code review process"
@@ -36,80 +72,10 @@ protocol "pr-review" {
       type        = "string"
       description = "Pull request URL"
     }
+
     field "urgency" {
       type        = "enum(low,normal,high)"
       description = "Review priority"
-    }
-  }
-}
-
-protocol "cicd" {
-  description = "Continuous integration and deployment"
-  roles       = ["provider", "consumer"]
-}
-
-protocol "agile" {
-  description = "Agile sprint management"
-  roles       = ["provider", "consumer"]
-
-  message "sprint-backlog" {
-    description = "Prioritized list of stories for the sprint"
-    tags        = ["agile"]
-
-    field "sprint_id" {
-      type        = "string"
-      description = "Sprint identifier"
-    }
-    field "stories" {
-      type        = "string[]"
-      description = "Ordered story IDs"
-    }
-    field "capacity" {
-      type        = "uint8"
-      unit        = "points"
-      description = "Team capacity"
-    }
-  }
-}
-
-protocol "design" {
-  description = "UI/UX design spec delivery"
-  roles       = ["provider", "consumer"]
-
-  message "design-spec" {
-    description = "Figma link + acceptance criteria"
-    tags        = ["process"]
-
-    field "figma_url" {
-      type        = "string"
-      description = "Design file URL"
-    }
-    field "feature_id" {
-      type        = "string"
-      description = "Feature tracker ID"
-    }
-  }
-}
-
-protocol "tickets" {
-  description = "Issue tracking and bug reporting"
-  roles       = ["provider", "consumer"]
-
-  message "bug-ticket" {
-    description = "Bug report with reproduction steps"
-    tags        = ["quality"]
-
-    field "ticket_id" {
-      type        = "string"
-      description = "Issue tracker ID"
-    }
-    field "severity" {
-      type        = "enum(critical,major,minor)"
-      description = "Bug severity"
-    }
-    field "repro_steps" {
-      type        = "string"
-      description = "Steps to reproduce"
     }
   }
 }
@@ -122,13 +88,14 @@ protocol "release" {
     description = "Release approval or rejection"
     tags        = ["quality"]
 
-    field "build_id" {
-      type        = "string"
-      description = "Build/version identifier"
-    }
     field "approved" {
       type        = "bool"
       description = "Pass or fail"
+    }
+
+    field "build_id" {
+      type        = "string"
+      description = "Build/version identifier"
     }
   }
 }
@@ -138,80 +105,42 @@ protocol "test-suites" {
   roles       = ["provider", "consumer"]
 }
 
-protocol "feedback" {
-  description = "Customer feedback stream"
+protocol "tickets" {
+  description = "Issue tracking and bug reporting"
   roles       = ["provider", "consumer"]
-}
 
-# ── Component definitions ─────────────────
+  message "bug-ticket" {
+    description = "Bug report with reproduction steps"
+    tags        = ["quality"]
 
-component "engineering" {
-  description = "Product engineering department"
-  icon        = "gears"
-  tags        = ["department", "technical"]
-  leaf        = false
+    field "repro_steps" {
+      type        = "string"
+      description = "Steps to reproduce"
+    }
 
-  port "sprint-in" {
-    description = "Sprint backlog intake"
-    protocol    = "agile"
-    role        = "consumer"
-    external    = true
-    tags        = ["process", "agile"]
-  }
+    field "severity" {
+      type        = "enum(critical,major,minor)"
+      description = "Bug severity"
+    }
 
-  port "bug-in" {
-    description = "Bug intake from QA"
-    protocol    = "tickets"
-    role        = "consumer"
-    external    = true
-    tags        = ["process", "quality"]
-  }
-
-  instance "frontend-team" {
-    source = "frontend-team"
-  }
-
-  instance "backend-team" {
-    source = "backend-team"
-  }
-
-  instance "platform-team" {
-    source = "platform-team"
-  }
-
-  connection "code-review" {
-    description = "Pull request review flow between teams"
-    tags        = ["process", "collaboration"]
-    from        = "frontend-team/review"
-    to          = "backend-team/review"
-  }
-
-  connection "deploy-pipeline" {
-    description = "Platform team provides CI/CD to all engineering"
-    tags        = ["process", "infra"]
-    from        = "platform-team/deploy-out"
-    to          = "frontend-team/deploy-in"
+    field "ticket_id" {
+      type        = "string"
+      description = "Issue tracker ID"
+    }
   }
 }
 
-component "frontend-team" {
-  description = "Web and mobile client engineers"
-  icon        = "desktop"
-  tags        = ["team", "technical"]
+component "automation-qa" {
+  description = "Test automation engineers"
+  icon        = "robot"
+  tags        = ["team", "testing", "technical"]
   leaf        = true
 
-  port "review" {
-    description = "Code review interface"
-    protocol    = "pr-review"
-    role        = "peer"
-    tags        = ["process", "collaboration"]
-  }
-
-  port "deploy-in" {
-    description = "Receives deployments from platform"
-    protocol    = "cicd"
-    role        = "consumer"
-    tags        = ["process", "infra"]
+  port "suites-out" {
+    description = "Regression suites"
+    protocol    = "test-suites"
+    role        = "provider"
+    tags        = ["process", "testing"]
   }
 }
 
@@ -227,6 +156,96 @@ component "backend-team" {
     role        = "peer"
     tags        = ["process", "collaboration"]
   }
+}
+
+component "designers" {
+  description = "UX/UI design team"
+  icon        = "palette"
+  tags        = ["team", "creative"]
+  leaf        = true
+
+  port "design-out" {
+    description = "Design spec delivery"
+    protocol    = "design"
+    role        = "provider"
+    tags        = ["process"]
+    external    = true
+  }
+}
+
+component "engineering" {
+  description = "Product engineering department"
+  icon        = "gears"
+  tags        = ["department", "technical"]
+
+  port "bug-in" {
+    description = "Bug intake from QA"
+    protocol    = "tickets"
+    role        = "consumer"
+    tags        = ["process", "quality"]
+    external    = true
+  }
+
+  port "sprint-in" {
+    description = "Sprint backlog intake"
+    protocol    = "agile"
+    role        = "consumer"
+    tags        = ["process", "agile"]
+    external    = true
+  }
+
+  instance "backend-team" { source = "backend-team" }
+
+  instance "frontend-team" { source = "frontend-team" }
+
+  instance "platform-team" { source = "platform-team" }
+
+  connection "code-review" {
+    description  = "Pull request review flow between teams"
+    tags         = ["process", "collaboration"]
+    from         = "frontend-team/review"
+    to           = "backend-team/review"
+  }
+
+  connection "deploy-pipeline" {
+    description  = "Platform team provides CI/CD to all engineering"
+    tags         = ["process", "infra"]
+    from         = "platform-team/deploy-out"
+    to           = "frontend-team/deploy-in"
+  }
+}
+
+component "frontend-team" {
+  description = "Web and mobile client engineers"
+  icon        = "desktop"
+  tags        = ["team", "technical"]
+  leaf        = true
+
+  port "deploy-in" {
+    description = "Receives deployments from platform"
+    protocol    = "cicd"
+    role        = "consumer"
+    tags        = ["process", "infra"]
+  }
+
+  port "review" {
+    description = "Code review interface"
+    protocol    = "pr-review"
+    role        = "peer"
+    tags        = ["process", "collaboration"]
+  }
+}
+
+component "manual-qa" {
+  description = "Manual / exploratory testing team"
+  icon        = "clipboard-check"
+  tags        = ["team", "testing"]
+  leaf        = true
+}
+
+component "operations" {
+  icon        = "headset"
+  tags        = ["department", "infra"]
 }
 
 component "platform-team" {
@@ -247,45 +266,40 @@ component "product" {
   description = "Product management"
   icon        = "lightbulb"
   tags        = ["department", "business"]
-  leaf        = false
 
-  port "sprint-out" {
-    description = "Sends sprint backlogs to engineering"
-    protocol    = "agile"
-    role        = "provider"
+  port "feedback-in" {
+    description = "Customer feedback from Sales"
+    protocol    = "feedback"
+    role        = "consumer"
+    tags        = ["process", "business"]
     external    = true
-    tags        = ["process", "agile"]
   }
 
   port "signoff-in" {
     description = "Release sign-off from QA"
     protocol    = "release"
     role        = "consumer"
-    external    = true
     tags        = ["process", "quality"]
-  }
-
-  port "feedback-in" {
-    description = "Customer feedback from Sales"
-    protocol    = "feedback"
-    role        = "consumer"
     external    = true
-    tags        = ["process", "business"]
   }
 
-  instance "product-managers" {
-    source = "product-managers"
+  port "sprint-out" {
+    description = "Sends sprint backlogs to engineering"
+    protocol    = "agile"
+    role        = "provider"
+    tags        = ["process", "agile"]
+    external    = true
   }
 
-  instance "designers" {
-    source = "designers"
-  }
+  instance "designers" { source = "designers" }
+
+  instance "product-managers" { source = "product-managers" }
 
   connection "design-handoff" {
-    description = "Designers deliver specs to PMs for grooming"
-    tags        = ["process"]
-    from        = "designers/design-out"
-    to          = "product-managers"
+    description  = "Designers deliver specs to PMs for grooming"
+    tags         = ["process"]
+    from         = "designers/design-out"
+    to           = "product-managers"
   }
 }
 
@@ -296,77 +310,36 @@ component "product-managers" {
   leaf        = true
 }
 
-component "designers" {
-  description = "UX/UI design team"
-  icon        = "palette"
-  tags        = ["team", "creative"]
-  leaf        = true
-
-  port "design-out" {
-    description = "Design spec delivery"
-    protocol    = "design"
-    role        = "provider"
-    external    = true
-    tags        = ["process"]
-  }
-}
-
 component "qa" {
   description = "Quality assurance department"
   icon        = "vial"
   tags        = ["department", "technical"]
-  leaf        = false
 
   port "bug-out" {
     description = "Files bug reports against engineering"
     protocol    = "tickets"
     role        = "provider"
-    external    = true
     tags        = ["process", "quality"]
+    external    = true
   }
 
   port "signoff-out" {
     description = "Approves releases"
     protocol    = "release"
     role        = "provider"
-    external    = true
     tags        = ["process", "quality"]
+    external    = true
   }
 
-  instance "manual-qa" {
-    source = "manual-qa"
-  }
+  instance "automation-qa" { source = "automation-qa" }
 
-  instance "automation-qa" {
-    source = "automation-qa"
-  }
+  instance "manual-qa" { source = "manual-qa" }
 
   connection "test-handoff" {
-    description = "Automation team provides regression suites to manual QA"
-    tags        = ["process", "testing"]
-    from        = "automation-qa/suites-out"
-    to          = "manual-qa"
-  }
-}
-
-component "manual-qa" {
-  description = "Manual / exploratory testing team"
-  icon        = "clipboard-check"
-  tags        = ["team", "testing"]
-  leaf        = true
-}
-
-component "automation-qa" {
-  description = "Test automation engineers"
-  icon        = "robot"
-  tags        = ["team", "testing", "technical"]
-  leaf        = true
-
-  port "suites-out" {
-    description = "Regression suites"
-    protocol    = "test-suites"
-    role        = "provider"
-    tags        = ["process", "testing"]
+    description  = "Automation team provides regression suites to manual QA"
+    tags         = ["process", "testing"]
+    from         = "automation-qa/suites-out"
+    to           = "manual-qa"
   }
 }
 
@@ -384,71 +357,45 @@ component "sales" {
   }
 }
 
-# Intentionally incomplete — W001 + W004
-component "operations" {
-  icon = "headset"
-  tags = ["department", "infra"]
-  leaf = false
-  # no description → W004
-  # no children    → W001
-}
-
-# ── System ────────────────────────────────
-
 system "acme-software" {
   description = "Mid-sized product software company"
   tags        = ["organization", "software"]
-  level       = 0
 
-  # ── Instances ──────────────────────────────
+  instance "engineering" { source = "engineering" }
 
-  instance "engineering" {
-    source = "engineering"
-  }
+  instance "operations" { source = "operations" }
 
-  instance "product" {
-    source = "product"
-  }
+  instance "product" { source = "product" }
 
-  instance "qa" {
-    source = "qa"
-  }
+  instance "qa" { source = "qa" }
 
-  instance "sales" {
-    source = "sales"
-  }
-
-  instance "operations" {
-    source = "operations"
-  }
-
-  # ── Cross-department processes (connections) ─
-
-  connection "sprint-planning" {
-    description = "Bi-weekly sprint planning: Product → Engineering"
-    tags        = ["process", "agile"]
-    from        = "product/sprint-out"
-    to          = "engineering/sprint-in"
-  }
+  instance "sales" { source = "sales" }
 
   connection "bug-reports" {
-    description = "QA files bugs against Engineering"
-    tags        = ["process", "quality"]
-    from        = "qa/bug-out"
-    to          = "engineering/bug-in"
-  }
-
-  connection "release-sign-off" {
-    description = "QA approves a build for release"
-    tags        = ["process", "quality"]
-    from        = "qa/signoff-out"
-    to          = "product/signoff-in"
+    description  = "QA files bugs against Engineering"
+    tags         = ["process", "quality"]
+    from         = "/acme-software/qa/bug-out"
+    to           = "/acme-software/engineering/bug-in"
   }
 
   connection "customer-feedback" {
-    description = "Sales relays customer feedback to Product"
-    tags        = ["process", "business"]
-    from        = "sales/feedback-out"
-    to          = "product/feedback-in"
+    description  = "Sales relays customer feedback to Product"
+    tags         = ["process", "business"]
+    from         = "/acme-software/sales/feedback-out"
+    to           = "/acme-software/product/feedback-in"
+  }
+
+  connection "release-sign-off" {
+    description  = "QA approves a build for release"
+    tags         = ["process", "quality"]
+    from         = "/acme-software/qa/signoff-out"
+    to           = "/acme-software/product/signoff-in"
+  }
+
+  connection "sprint-planning" {
+    description  = "Bi-weekly sprint planning: Product → Engineering"
+    tags         = ["process", "agile"]
+    from         = "/acme-software/product/sprint-out"
+    to           = "/acme-software/engineering/sprint-in"
   }
 }

--- a/examples/software-house/views.hcl
+++ b/examples/software-house/views.hcl
@@ -1,19 +1,23 @@
-view "org-chart" {
-  description = "Full organizational overview"
-  system      = "acme-software"
-
-  filter {
-    max_level = 1
-  }
-}
-
 view "engineering-teams" {
   description = "Engineering department internal structure"
   system      = "acme-software"
 
   filter {
-    components = ["engineering"]
-    max_level  = 3
+    max_level     = 3
+    components    = ["engineering"]
+  }
+}
+
+view "main" {
+  system      = "acme-software"
+}
+
+view "org-chart" {
+  description = "Full organizational overview"
+  system      = "acme-software"
+
+  filter {
+    max_level     = 1
   }
 }
 

--- a/examples/web-app/system.hcl
+++ b/examples/web-app/system.hcl
@@ -1,303 +1,301 @@
 project {
-    name    = "web-app"
-    version = "0.3.0"
-    authors = ["rhizz-examples"]
-}
-
-protocol "jwt" {
-    description = "JWT authentication protocol"
-    roles       = ["provider", "consumer"]
-
-    message "login-request" {
-        description = "Login credentials submitted by the user"
-        field "username" {
-            type        = "string"
-            description = "User email address"
-        }
-        field "password" {
-            type        = "string"
-            description = "Hashed password"
-        }
-    }
-
-    message "auth-response" {
-        description = "JWT token issued after successful authentication"
-        field "token" {
-            type        = "string"
-            description = "Signed JWT access token"
-        }
-        field "expires" {
-            type        = "uint32"
-            description = "Token lifetime in seconds"
-        }
-    }
+  name    = "web-app"
+  version = "0.3.0"
+  authors = ["rhizz-examples"]
 }
 
 protocol "https" {
-    description = "HTTPS REST API"
-    roles       = ["provider", "consumer"]
+  description = "HTTPS REST API"
+  roles       = ["provider", "consumer"]
 
-    message "api-request" {
-        description = "Generic HTTP API request"
-        field "method" {
-            type        = "string"
-            description = "HTTP method (GET, POST, …)"
-        }
-        field "path" {
-            type        = "string"
-            description = "Request path"
-        }
-        field "payload" {
-            type        = "bytes"
-            description = "Request body"
-        }
+  message "api-request" {
+    description = "Generic HTTP API request"
+
+    field "method" {
+      type        = "string"
+      description = "HTTP method (GET, POST, …)"
     }
 
-    message "api-response" {
-        description = "Generic HTTP API response"
-        field "status" {
-            type        = "uint16"
-            description = "HTTP status code"
-        }
-        field "payload" {
-            type        = "bytes"
-            description = "Response body"
-        }
+    field "path" {
+      type        = "string"
+      description = "Request path"
     }
+
+    field "payload" {
+      type        = "bytes"
+      description = "Request body"
+    }
+  }
+
+  message "api-response" {
+    description = "Generic HTTP API response"
+
+    field "payload" {
+      type        = "bytes"
+      description = "Response body"
+    }
+
+    field "status" {
+      type        = "uint16"
+      description = "HTTP status code"
+    }
+  }
 }
 
-protocol "ui-nav" {
-    description = "Frontend page routing and navigation events"
-    roles       = ["provider", "consumer"]
+protocol "jwt" {
+  description = "JWT authentication protocol"
+  roles       = ["provider", "consumer"]
 
-    message "nav-event" {
-        description = "Signals a page transition"
-        field "destination" {
-            type        = "string"
-            description = "Target page identifier"
-        }
+  message "auth-response" {
+    description = "JWT token issued after successful authentication"
+
+    field "expires" {
+      type        = "uint32"
+      description = "Token lifetime in seconds"
     }
-}
 
-protocol "websocket" {
-    description = "Real-time bidirectional WebSocket event channel"
-    roles       = ["provider", "consumer"]
-
-    message "match-event" {
-        description = "A new match created by a right swipe"
-        field "horse_id" {
-            type        = "uint32"
-            description = "Horse profile ID"
-        }
-        field "match_id" {
-            type        = "uint32"
-            description = "Unique match identifier"
-        }
+    field "token" {
+      type        = "string"
+      description = "Signed JWT access token"
     }
+  }
+
+  message "login-request" {
+    description = "Login credentials submitted by the user"
+
+    field "password" {
+      type        = "string"
+      description = "Hashed password"
+    }
+
+    field "username" {
+      type        = "string"
+      description = "User email address"
+    }
+  }
 }
 
 protocol "postgresql" {
-    description = "PostgreSQL wire protocol"
-    roles       = ["provider", "consumer"]
+  description = "PostgreSQL wire protocol"
+  roles       = ["provider", "consumer"]
 
-    message "db-query" {
-        description = "SQL query sent to the database"
-        field "sql" {
-            type        = "string"
-            description = "SQL statement"
-        }
-        field "params" {
-            type        = "bytes"
-            description = "Bound query parameters"
-        }
+  message "db-query" {
+    description = "SQL query sent to the database"
+
+    field "params" {
+      type        = "bytes"
+      description = "Bound query parameters"
     }
+
+    field "sql" {
+      type        = "string"
+      description = "SQL statement"
+    }
+  }
 }
 
-component "login_page" {
-    description = "Available at /login"
-    leaf = true
+protocol "ui-nav" {
+  description = "Frontend page routing and navigation events"
+  roles       = ["provider", "consumer"]
 
-    port "nav-out" {
-        description = "Navigation event emitted after a successful login"
-        protocol    = "ui-nav"
-        role        = "provider"
+  message "nav-event" {
+    description = "Signals a page transition"
+
+    field "destination" {
+      type        = "string"
+      description = "Target page identifier"
     }
+  }
 }
 
-component "settings_page" {
-    description = "Available at /settings"
-    leaf = true
+protocol "websocket" {
+  description = "Real-time bidirectional WebSocket event channel"
+  roles       = ["provider", "consumer"]
 
-    port "nav-in" {
-        description = "Navigation event that opens the settings page"
-        protocol    = "ui-nav"
-        role        = "consumer"
-    }
-}
+  message "match-event" {
+    description = "A new match created by a right swipe"
 
-component "swipe_mode" {
-    description = "Swipe horses left or right to like or pass"
-    leaf = true
-
-    port "match-out" {
-        description = "Match event emitted when a user swipes right"
-        protocol    = "websocket"
-        role        = "provider"
-    }
-}
-
-component "chat_mode" {
-    description = "Chat with horses you have matched with"
-    leaf = true
-
-    port "match-in" {
-        description = "Match event that opens a new chat thread"
-        protocol    = "websocket"
-        role        = "consumer"
-    }
-}
-
-component "main_app" {
-    description = "Root page (/), shows pictures of horses"
-
-    port "nav-in" {
-        description = "Navigation event that enters the main application"
-        protocol    = "ui-nav"
-        role        = "consumer"
+    field "horse_id" {
+      type        = "uint32"
+      description = "Horse profile ID"
     }
 
-    port "settings-out" {
-        description = "Navigation event that opens the settings page"
-        protocol    = "ui-nav"
-        role        = "provider"
+    field "match_id" {
+      type        = "uint32"
+      description = "Unique match identifier"
     }
-
-    instance "swipe_mode" {
-        source = "swipe_mode"
-    }
-
-    instance "chat_mode" {
-        source = "chat_mode"
-    }
-
-    connection "mode-switch" {
-        description = "Match event bridge: new matches open a chat thread"
-        from = "swipe_mode/match-out"
-        to   = "chat_mode/match-in"
-    }
-}
-
-component "frontend" {
-    description = "Frontend application"
-
-    port "auth-out" {
-        description = "Authentication requests sent to the backend"
-        protocol    = "jwt"
-        role        = "consumer"
-        external    = true
-    }
-
-    port "api-out" {
-        description = "REST API calls sent to the backend"
-        protocol    = "https"
-        role        = "consumer"
-        external    = true
-    }
-
-    instance "login_page" {
-        source = "login_page"
-    }
-
-    instance "settings_page" {
-        source = "settings_page"
-    }
-
-    instance "main_app" {
-        source = "main_app"
-    }
-
-    connection "login-to-app" {
-        description = "Navigation from the login page into the main application"
-        from = "login_page/nav-out"
-        to   = "main_app/nav-in"
-    }
-
-    connection "app-to-settings" {
-        description = "Navigation from the main application to the settings page"
-        from = "main_app/settings-out"
-        to   = "settings_page/nav-in"
-    }
+  }
 }
 
 component "backend" {
-    description = "Backend server"
-    leaf = true
+  description = "Backend server"
+  leaf        = true
 
-    port "auth-in" {
-        description = "JWT authentication endpoint"
-        protocol    = "jwt"
-        role        = "provider"
-        external    = true
-    }
+  port "api-in" {
+    description = "REST API endpoint"
+    protocol    = "https"
+    role        = "provider"
+    external    = true
+  }
 
-    port "api-in" {
-        description = "REST API endpoint"
-        protocol    = "https"
-        role        = "provider"
-        external    = true
-    }
+  port "auth-in" {
+    description = "JWT authentication endpoint"
+    protocol    = "jwt"
+    role        = "provider"
+    external    = true
+  }
 
-    port "db-out" {
-        description = "Database query connection"
-        protocol    = "postgresql"
-        role        = "provider"
-        external    = true
-    }
+  port "db-out" {
+    description = "Database query connection"
+    protocol    = "postgresql"
+    role        = "provider"
+    external    = true
+  }
+}
+
+component "chat_mode" {
+  description = "Chat with horses you have matched with"
+  leaf        = true
+
+  port "match-in" {
+    description = "Match event that opens a new chat thread"
+    protocol    = "websocket"
+    role        = "consumer"
+  }
 }
 
 component "database" {
-    description = "PostgreSQL database"
-    leaf = true
+  description = "PostgreSQL database"
+  leaf        = true
 
-    port "db-in" {
-        description = "Database query listener"
-        protocol    = "postgresql"
-        role        = "consumer"
-        external    = true
-    }
+  port "db-in" {
+    description = "Database query listener"
+    protocol    = "postgresql"
+    role        = "consumer"
+    external    = true
+  }
+}
+
+component "frontend" {
+  description = "Frontend application"
+
+  port "api-out" {
+    description = "REST API calls sent to the backend"
+    protocol    = "https"
+    role        = "consumer"
+    external    = true
+  }
+
+  port "auth-out" {
+    description = "Authentication requests sent to the backend"
+    protocol    = "jwt"
+    role        = "consumer"
+    external    = true
+  }
+
+  instance "login_page" { source = "login_page" }
+
+  instance "main_app" { source = "main_app" }
+
+  instance "settings_page" { source = "settings_page" }
+
+  connection "app-to-settings" {
+    description  = "Navigation from the main application to the settings page"
+    from         = "main_app/settings-out"
+    to           = "settings_page/nav-in"
+  }
+
+  connection "login-to-app" {
+    description  = "Navigation from the login page into the main application"
+    from         = "login_page/nav-out"
+    to           = "main_app/nav-in"
+  }
+}
+
+component "login_page" {
+  description = "Available at /login"
+  leaf        = true
+
+  port "nav-out" {
+    description = "Navigation event emitted after a successful login"
+    protocol    = "ui-nav"
+    role        = "provider"
+  }
+}
+
+component "main_app" {
+  description = "Root page (/), shows pictures of horses"
+
+  port "nav-in" {
+    description = "Navigation event that enters the main application"
+    protocol    = "ui-nav"
+    role        = "consumer"
+  }
+
+  port "settings-out" {
+    description = "Navigation event that opens the settings page"
+    protocol    = "ui-nav"
+    role        = "provider"
+  }
+
+  instance "chat_mode" { source = "chat_mode" }
+
+  instance "swipe_mode" { source = "swipe_mode" }
+
+  connection "mode-switch" {
+    description  = "Match event bridge: new matches open a chat thread"
+    from         = "swipe_mode/match-out"
+    to           = "chat_mode/match-in"
+  }
+}
+
+component "settings_page" {
+  description = "Available at /settings"
+  leaf        = true
+
+  port "nav-in" {
+    description = "Navigation event that opens the settings page"
+    protocol    = "ui-nav"
+    role        = "consumer"
+  }
+}
+
+component "swipe_mode" {
+  description = "Swipe horses left or right to like or pass"
+  leaf        = true
+
+  port "match-out" {
+    description = "Match event emitted when a user swipes right"
+    protocol    = "websocket"
+    role        = "provider"
+  }
 }
 
 system "Web Application" {
-    description = "Web Application - Tinder for Horses"
-    tags        = ["web", "application"]
+  description = "Web Application - Tinder for Horses"
+  tags        = ["web", "application"]
 
-    instance "frontend" {
-        source = "frontend"
-    }
+  instance "backend" { source = "backend" }
 
-    instance "backend" {
-        source = "backend"
-    }
+  instance "database" { source = "database" }
 
-    instance "database" {
-        source = "database"
-    }
+  instance "frontend" { source = "frontend" }
 
-    connection "database-connection" {
-        description = "TLS connection from the backend to the database"
-        from = "backend/db-out"
-        to   = "database/db-in"
-    }
+  connection "auth" {
+    description  = "JWT authentication API"
+    from         = "/Web Application/frontend/auth-out"
+    to           = "/Web Application/backend/auth-in"
+  }
 
-    connection "rest-api" {
-        description = "REST API served by the backend to the frontend"
-        from = "frontend/api-out"
-        to   = "backend/api-in"
-    }
+  connection "database-connection" {
+    description  = "TLS connection from the backend to the database"
+    from         = "/Web Application/backend/db-out"
+    to           = "/Web Application/database/db-in"
+  }
 
-    connection "auth" {
-        description = "JWT authentication API"
-        from = "frontend/auth-out"
-        to   = "backend/auth-in"
-    }
+  connection "rest-api" {
+    description  = "REST API served by the backend to the frontend"
+    from         = "/Web Application/frontend/api-out"
+    to           = "/Web Application/backend/api-in"
+  }
 }

--- a/examples/web-app/views.hcl
+++ b/examples/web-app/views.hcl
@@ -1,6 +1,3 @@
-# ── Architect overview ────────────────────────────────────────────────────────
-# Full system detail: every component, every connection, and all message schemas.
-# Intended for a system architect who needs the complete picture.
 view "architect-overview" {
   description = "Full system architecture with all components and message schemas"
   system      = "Web Application"
@@ -10,29 +7,23 @@ view "architect-overview" {
   }
 }
 
-# ── Frontend developer ────────────────────────────────────────────────────────
-# Zooms into the frontend sub-tree: login page, settings page, and the main app
-# (swipe mode + chat mode) with all navigation messages shown.
-view "frontend-internals" {
-  description = "Frontend application internals for frontend developers"
-  system      = "Web Application"
-
-  filter {
-    components    = ["frontend"]
-    max_level     = 3
-    show_messages = true
-  }
-}
-
-# ── Backend developer ─────────────────────────────────────────────────────────
-# Shows the backend component in isolation with all its ports and message types.
-# Useful for developers who own the server-side API.
 view "backend-internals" {
   description = "Backend server ports and message types for backend developers"
   system      = "Web Application"
 
   filter {
     components    = ["backend"]
+    show_messages = true
+  }
+}
+
+view "frontend-internals" {
+  description = "Frontend application internals for frontend developers"
+  system      = "Web Application"
+
+  filter {
+    max_level     = 3
+    components    = ["frontend"]
     show_messages = true
   }
 }


### PR DESCRIPTION
New Fmt subcommand: loads the project, compiles it, and rewrites the canonical system.hcl + views.hcl projections in place (atomic temp+rename, never clobbering on compile errors). Prints cargo-fmt-style messages ('1 file reformatted (system.hcl)'). With --check, makes no filesystem changes and exits 1 with a git-style unified diff of exactly what would change (via the similar crate). Well-formatted projects are a no-op and --check exits 0. Tests: parsing, no-op check, messy->format->clean cycle, no-write-on-error, views.hcl generation. 24 lib + 7 integration tests green; clippy/fmt clean.