### PR TITLE
feat(views): add view-level text annotations [chromatic]

### DIFF
--- a/crates/rhizz-core/src/lib.rs
+++ b/crates/rhizz-core/src/lib.rs
@@ -19,10 +19,10 @@ pub mod validate;
 pub use diagnostics::{Diagnostic, DiagnosticCode, Level};
 pub use examples::{ExampleFile, ExampleProject, example_projects};
 pub use model::{
-    Component, ComponentId, ComponentKind, ComponentParent, Connection, ConnectionEndpoint,
-    ConnectionId, ConnectionLayout, ConnectionSide, Field, FieldId, Message, MessageId, Model,
-    NodeLayout, Port, PortId, Project, Protocol, ProtocolId, System, SystemId, View,
-    ViewDefinition, ViewFilter, ViewFilterDefinition,
+    Annotation, Component, ComponentId, ComponentKind, ComponentParent, Connection,
+    ConnectionEndpoint, ConnectionId, ConnectionLayout, ConnectionSide, Field, FieldId, Message,
+    MessageId, Model, NodeLayout, Port, PortId, Project, Protocol, ProtocolId, System, SystemId,
+    View, ViewDefinition, ViewFilter, ViewFilterDefinition,
 };
 pub use score::{CategoryScore, ScoreReport, score};
 pub use serialize::{parse_views, serialize_model, serialize_resolved_views, serialize_views};

--- a/crates/rhizz-core/src/model.rs
+++ b/crates/rhizz-core/src/model.rs
@@ -523,6 +523,14 @@ pub struct Annotation {
     pub x: f64,
     /// Y coordinate on canvas (absolute, in world units).
     pub y: f64,
+    /// Font size multiplier; 1.0 = 100% (the default size).
+    #[serde(default = "default_annotation_scale")]
+    pub scale: f64,
+}
+
+/// Default annotation scale: 100%.
+const fn default_annotation_scale() -> f64 {
+    1.0
 }
 
 /// A view definition containing filter, output settings, and node layouts.

--- a/crates/rhizz-core/src/model.rs
+++ b/crates/rhizz-core/src/model.rs
@@ -509,6 +509,22 @@ pub struct ConnectionLayout {
     pub end_side: Option<ConnectionSide>,
 }
 
+/// A text annotation placed at an absolute position on a view canvas.
+///
+/// Annotations are view-level diagram metadata (like node/connection
+/// layouts): they are saved in `views.hcl` and never in the system model.
+/// Position is absolute in canvas units; anchors are explicitly not supported
+/// (the task deliberately dropped node anchoring).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Annotation {
+    /// Human-readable text. May contain `\n` for multi-line labels.
+    pub text: String,
+    /// X coordinate on canvas (absolute, in world units).
+    pub x: f64,
+    /// Y coordinate on canvas (absolute, in world units).
+    pub y: f64,
+}
+
 /// A view definition containing filter, output settings, and node layouts.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct ViewDefinition {
@@ -532,6 +548,9 @@ pub struct ViewDefinition {
     /// Placed connection layouts for this view.
     #[serde(default)]
     pub connections: Vec<ConnectionLayout>,
+    /// Text annotations placed on this view's canvas.
+    #[serde(default)]
+    pub annotations: Vec<Annotation>,
 }
 
 impl ViewDefinition {
@@ -561,6 +580,7 @@ impl ViewDefinition {
             },
             nodes: Vec::new(),
             connections: Vec::new(),
+            annotations: Vec::new(),
         }
     }
 }

--- a/crates/rhizz-core/src/serialize.rs
+++ b/crates/rhizz-core/src/serialize.rs
@@ -18,9 +18,9 @@ use std::collections::HashSet;
 use std::fmt::Write as _;
 
 use crate::model::{
-    BorderStyle, Component, ComponentKind, ComponentParent, Connection, ConnectionEndpoint,
-    ConnectionLayout, ConnectionSide, Field, Message, Model, NodeLayout, Port, Project, Protocol,
-    System, View, ViewDefinition, ViewFilterDefinition,
+    Annotation, BorderStyle, Component, ComponentKind, ComponentParent, Connection,
+    ConnectionEndpoint, ConnectionLayout, ConnectionSide, Field, Message, Model, NodeLayout, Port,
+    Project, Protocol, System, View, ViewDefinition, ViewFilterDefinition,
 };
 use anyhow::Context;
 use serde::Deserialize;
@@ -672,6 +672,14 @@ fn serialize_single_view(out: &mut String, view: &ViewDefinition) {
         serialize_connection_layout(out, conn);
     }
 
+    let mut sorted_anns: Vec<&Annotation> = view.annotations.iter().collect();
+    sorted_anns.sort_by(|a, b| a.text.cmp(&b.text));
+
+    for ann in sorted_anns {
+        out.push('\n');
+        serialize_annotation(out, ann);
+    }
+
     out.push_str("}\n");
 }
 
@@ -742,6 +750,15 @@ fn serialize_connection_layout(out: &mut String, conn: &ConnectionLayout) {
     out.push_str("  }\n");
 }
 
+/// Serialize one annotation block: `annotation { x y text }`.
+fn serialize_annotation(out: &mut String, ann: &Annotation) {
+    let _ = writeln!(out, "  annotation {{");
+    let _ = writeln!(out, "    x    = {}", format_number(ann.x));
+    let _ = writeln!(out, "    y    = {}", format_number(ann.y));
+    let _ = writeln!(out, "    text = {}", escape_string(&ann.text));
+    out.push_str("  }\n");
+}
+
 fn format_number(n: f64) -> String {
     if n.fract() == 0.0 && n.is_finite() {
         // The value is a finite whole number. Clamp to the i64 range so the
@@ -789,6 +806,13 @@ struct RawConnectionLayoutAttrs {
     end_side: Option<String>,
 }
 
+#[derive(Deserialize, Default)]
+struct RawAnnotationAttrs {
+    x: Option<f64>,
+    y: Option<f64>,
+    text: Option<String>,
+}
+
 fn parse_connection_side(s: Option<&str>) -> Option<ConnectionSide> {
     match s {
         Some("top") => Some(ConnectionSide::Top),
@@ -823,6 +847,7 @@ pub fn parse_views(hcl_str: &str) -> anyhow::Result<Vec<ViewDefinition>> {
             let mut filter = ViewFilterDefinition::default();
             let mut nodes = Vec::new();
             let mut connections = Vec::new();
+            let mut annotations = Vec::new();
 
             for child in block.body().blocks() {
                 match child.identifier() {
@@ -870,6 +895,15 @@ pub fn parse_views(hcl_str: &str) -> anyhow::Result<Vec<ViewDefinition>> {
                             end_side: parse_connection_side(ca.end_side.as_deref()),
                         });
                     }
+                    "annotation" => {
+                        let aa: RawAnnotationAttrs = hcl::from_body(child.body().clone())
+                            .context("failed to deserialize annotation attributes")?;
+                        annotations.push(Annotation {
+                            text: aa.text.unwrap_or_default(),
+                            x: aa.x.unwrap_or(0.0),
+                            y: aa.y.unwrap_or(0.0),
+                        });
+                    }
                     _ => {}
                 }
             }
@@ -882,6 +916,7 @@ pub fn parse_views(hcl_str: &str) -> anyhow::Result<Vec<ViewDefinition>> {
                 filter,
                 nodes,
                 connections,
+                annotations,
             });
         }
     }
@@ -1723,5 +1758,46 @@ view "main" {
             1,
             "duplicate view must be emitted once: {out}"
         );
+    }
+
+    #[test]
+    fn annotations_round_trip_through_views_hcl() {
+        let hcl = r#"view "overview" {
+  system = "s"
+  annotation {
+    x    = 12.5
+    y    = -3
+    text = "First line\nSecond line"
+  }
+  annotation {
+    x    = 0
+    y    = 100
+    text = "Standalone note"
+  }
+}
+"#;
+        let views = parse_views(hcl).expect("parse annotations");
+        assert_eq!(views.len(), 1);
+        let view = &views[0];
+        assert_eq!(view.annotations.len(), 2, "two annotations expected");
+        assert!(
+            (view.annotations[0].x - 12.5).abs() < 1e-9,
+            "x={}",
+            view.annotations[0].x
+        );
+        assert!(
+            (view.annotations[0].y + 3.0).abs() < 1e-9,
+            "y={}",
+            view.annotations[0].y
+        );
+        assert_eq!(view.annotations[0].text, "First line\nSecond line");
+        assert_eq!(view.annotations[1].text, "Standalone note");
+
+        // Serialize back and re-parse: idempotent round trip, sorted by text.
+        let serialized = serialize_views(&views);
+        let reparsed = parse_views(&serialized).expect("reparse");
+        assert_eq!(reparsed, views, "annotation round trip must be stable");
+        assert!(serialized.contains("annotation {"));
+        assert!(serialized.contains("text = \"First line\\nSecond line\""));
     }
 }

--- a/crates/rhizz-core/src/serialize.rs
+++ b/crates/rhizz-core/src/serialize.rs
@@ -750,12 +750,17 @@ fn serialize_connection_layout(out: &mut String, conn: &ConnectionLayout) {
     out.push_str("  }\n");
 }
 
-/// Serialize one annotation block: `annotation { x y text }`.
+/// Serialize one annotation block: `annotation { x y text scale }`.
 fn serialize_annotation(out: &mut String, ann: &Annotation) {
     let _ = writeln!(out, "  annotation {{");
-    let _ = writeln!(out, "    x    = {}", format_number(ann.x));
-    let _ = writeln!(out, "    y    = {}", format_number(ann.y));
-    let _ = writeln!(out, "    text = {}", escape_string(&ann.text));
+    let _ = writeln!(out, "    x     = {}", format_number(ann.x));
+    let _ = writeln!(out, "    y     = {}", format_number(ann.y));
+    let _ = writeln!(out, "    text  = {}", escape_string(&ann.text));
+    // Only emit scale when it differs from the 100% default, keeping
+    // canonical output stable for the common case.
+    if (ann.scale - 1.0).abs() > f64::EPSILON {
+        let _ = writeln!(out, "    scale = {}", format_number(ann.scale));
+    }
     out.push_str("  }\n");
 }
 
@@ -811,6 +816,7 @@ struct RawAnnotationAttrs {
     x: Option<f64>,
     y: Option<f64>,
     text: Option<String>,
+    scale: Option<f64>,
 }
 
 fn parse_connection_side(s: Option<&str>) -> Option<ConnectionSide> {
@@ -902,6 +908,7 @@ pub fn parse_views(hcl_str: &str) -> anyhow::Result<Vec<ViewDefinition>> {
                             text: aa.text.unwrap_or_default(),
                             x: aa.x.unwrap_or(0.0),
                             y: aa.y.unwrap_or(0.0),
+                            scale: aa.scale.unwrap_or(1.0),
                         });
                     }
                     _ => {}
@@ -1773,6 +1780,7 @@ view "main" {
     x    = 0
     y    = 100
     text = "Standalone note"
+    scale = 1.5
   }
 }
 "#;
@@ -1791,13 +1799,28 @@ view "main" {
             view.annotations[0].y
         );
         assert_eq!(view.annotations[0].text, "First line\nSecond line");
+        // Default scale (absent in HCL) is 1.0 (100%); explicit scale parses.
+        assert!(
+            (view.annotations[0].scale - 1.0).abs() < 1e-9,
+            "default scale should be 1.0, got {}",
+            view.annotations[0].scale
+        );
+        assert!(
+            (view.annotations[1].scale - 1.5).abs() < 1e-9,
+            "explicit scale should parse, got {}",
+            view.annotations[1].scale
+        );
         assert_eq!(view.annotations[1].text, "Standalone note");
 
-        // Serialize back and re-parse: idempotent round trip, sorted by text.
+        // Serialize back and re-parse: idempotent round trip, sorted by text,
+        // and the default scale is not emitted (canonical stability).
         let serialized = serialize_views(&views);
+        assert!(
+            serialized.contains("scale = 1.5"),
+            "non-default scale emitted: {serialized}"
+        );
         let reparsed = parse_views(&serialized).expect("reparse");
         assert_eq!(reparsed, views, "annotation round trip must be stable");
         assert!(serialized.contains("annotation {"));
-        assert!(serialized.contains("text = \"First line\\nSecond line\""));
     }
 }

--- a/crates/rhizz-core/tests/proptest_serialization.rs
+++ b/crates/rhizz-core/tests/proptest_serialization.rs
@@ -329,6 +329,7 @@ fn view_definition() -> impl Strategy<Value = ViewDefinition> {
                         },
                     )
                     .collect(),
+                annotations: vec![],
             },
         )
 }

--- a/crates/rhizz-wasm/tests/wasm_test.rs
+++ b/crates/rhizz-wasm/tests/wasm_test.rs
@@ -303,3 +303,39 @@ fn views_serialization_and_parsing_via_wasm() {
     assert!(serialized_hcl.contains("node \"server\""));
     assert!(serialized_hcl.contains("x          = 150"));
 }
+
+#[wasm_bindgen_test]
+fn annotations_round_trip_through_wasm_boundary() {
+    // Regression: annotations were silently dropped by serialize_views when
+    // the compiled wasm pkg predates annotation support in rhizz-core (serde
+    // ignores unknown JS fields). This test pins the JS<->Rust boundary: a
+    // JsValue carrying annotations must serialize to HCL and parse back.
+    let view = rhizz_core::ViewDefinition {
+        label: "main".to_string(),
+        description: String::new(),
+        tags: Vec::new(),
+        system: "web".to_string(),
+        filter: rhizz_core::ViewFilterDefinition::default(),
+        nodes: Vec::new(),
+        connections: Vec::new(),
+        annotations: vec![rhizz_core::Annotation {
+            text: "New note".to_string(),
+            x: 12.5,
+            y: -3.0,
+            scale: 1.5,
+        }],
+    };
+    let js = serde_wasm_bindgen::to_value(&vec![view]).expect("to_value should succeed");
+    let hcl = rhizz_wasm::serialize_views(js).expect("serialize_views should succeed");
+    assert!(hcl.contains("annotation {"), "annotation block must be serialized: {hcl}");
+    assert!(hcl.contains("New note"));
+    assert!(hcl.contains("scale = 1.5"));
+
+    let parsed = rhizz_wasm::parse_views(&hcl).expect("parse_views should succeed");
+    let reparsed: Vec<rhizz_core::ViewDefinition> =
+        serde_wasm_bindgen::from_value(parsed).expect("from_value should succeed");
+    assert_eq!(reparsed.len(), 1);
+    assert_eq!(reparsed[0].annotations.len(), 1);
+    assert_eq!(reparsed[0].annotations[0].text, "New note");
+    assert_eq!(reparsed[0].annotations[0].x, 12.5);
+}

--- a/crates/rhizz-wasm/tests/wasm_test.rs
+++ b/crates/rhizz-wasm/tests/wasm_test.rs
@@ -327,7 +327,10 @@ fn annotations_round_trip_through_wasm_boundary() {
     };
     let js = serde_wasm_bindgen::to_value(&vec![view]).expect("to_value should succeed");
     let hcl = rhizz_wasm::serialize_views(js).expect("serialize_views should succeed");
-    assert!(hcl.contains("annotation {"), "annotation block must be serialized: {hcl}");
+    assert!(
+        hcl.contains("annotation {"),
+        "annotation block must be serialized: {hcl}"
+    );
     assert!(hcl.contains("New note"));
     assert!(hcl.contains("scale = 1.5"));
 
@@ -337,5 +340,6 @@ fn annotations_round_trip_through_wasm_boundary() {
     assert_eq!(reparsed.len(), 1);
     assert_eq!(reparsed[0].annotations.len(), 1);
     assert_eq!(reparsed[0].annotations[0].text, "New note");
-    assert_eq!(reparsed[0].annotations[0].x, 12.5);
+    assert!((reparsed[0].annotations[0].x - 12.5).abs() < 1e-9);
+    assert!((reparsed[0].annotations[0].scale - 1.5).abs() < 1e-9);
 }

--- a/examples/drone/README.md
+++ b/examples/drone/README.md
@@ -13,6 +13,9 @@ station.
   same project, each with their own component tree
 - **Visual attributes** — the `gps` component sets `color`, `border`, and `font`
   to demonstrate how diagrams can be styled
+- **Annotations** — free-standing text notes on the main diagram, including one
+  with a non-default `scale` (font-size multiplier), showing how diagram editor
+  annotations are persisted as `annotation` blocks
 - **In-progress modeling** — the `ground-station-pc` component is non-leaf with
   no children and no description, triggering W001 and W004 warnings while still
   compiling cleanly
@@ -27,3 +30,4 @@ station.
 | ----------- | ------------------------------------------------------------------------ |
 | `system.hcl`  | Complete system model: project metadata, protocols, and both systems (`quadcopter`, `ground-control`) |
 | `views.hcl`   | Four view definitions with different filters                            |
+| `diagrams/main.hcl` | The main diagram's canvas layout, including free-standing annotation notes |

--- a/examples/drone/diagrams/main.hcl
+++ b/examples/drone/diagrams/main.hcl
@@ -104,4 +104,17 @@ view "main" {
     height     = 100
     text_align = "center"
   }
+
+  annotation {
+    x    = 400
+    y    = 480
+    text = "GPS feed is noisy — see issue #42"
+  }
+
+  annotation {
+    x    = -120
+    y    = 1960
+    text = "Ground station shown with optional goggles"
+    scale = 1.5
+  }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788179007,
-        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {

--- a/web/src/DocumentStore.svelte.ts
+++ b/web/src/DocumentStore.svelte.ts
@@ -1036,6 +1036,7 @@ export class DocumentStore {
       system,
       filter: { include_tags: [], exclude_tags: [], components: [] },
       nodes: [],
+      annotations: [],
     };
     this.views.push(v);
     notifyMutations({ op: "add_view", label, system });

--- a/web/src/rhizz_wasm_wrapper.ts
+++ b/web/src/rhizz_wasm_wrapper.ts
@@ -26,6 +26,8 @@ export interface Annotation {
   text: string;
   x: number;
   y: number;
+  /** Font size multiplier; 1 = 100% (default). */
+  scale?: number;
 }
 
 export interface ViewFilterDefinition {

--- a/web/src/rhizz_wasm_wrapper.ts
+++ b/web/src/rhizz_wasm_wrapper.ts
@@ -22,6 +22,12 @@ export interface ConnectionLayout {
   end_side?: string;
 }
 
+export interface Annotation {
+  text: string;
+  x: number;
+  y: number;
+}
+
 export interface ViewFilterDefinition {
   include_tags?: string[];
   exclude_tags?: string[];
@@ -38,6 +44,7 @@ export interface ViewDefinition {
   filter?: ViewFilterDefinition;
   nodes?: NodeLayout[];
   connections?: ConnectionLayout[];
+  annotations?: Annotation[];
 }
 
 export function compile_system(

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -284,7 +284,9 @@ let savedLayout = $state<Record<string, StoredBox>>({});
 let savedConnections = $state<Record<string, StoredConnection>>({});
 let annotations = $state<Annotation[]>([]);
 // Indices into `annotations` currently selected (for drag/delete).
-let selectedAnnotations = $state<Set<number>>(new Set());
+// SvelteSet (not a plain Set in $state) so in-place add/delete/clear are
+// tracked and the outline re-renders — mirrors the node `selectedKeys`.
+let selectedAnnotations = new SvelteSet<number>();
 // When editing an annotation's text inline (index, or null when not editing).
 let editingAnnotation = $state<number | null>(null);
 // The annotation object currently being edited (undefined when not editing).
@@ -969,8 +971,10 @@ type Interaction =
     offsetX: number;
     offsetY: number;
     startPositions: Record<number, { x: number; y: number }>;
-    /** Selected annotations' start positions (absolute), moved alongside nodes. */
-    annotationStartPositions?: { x: number; y: number }[];
+    /** Selected annotations' start positions (absolute), keyed by index, moved alongside nodes. */
+    annotationStartPositions?: Map<number, { x: number; y: number }>;
+    /** The annotation index grabbed to start an annotation-only drag (delta base). */
+    annotationAnchor?: number;
   }
   | {
     // Resizing any node via any of its 8 edge/corner handles.
@@ -1549,12 +1553,15 @@ function onNodeMouseDown(event: MouseEvent, index: number) {
   };
 }
 
-// Snapshot the currently selected annotations' positions for a group drag.
-function snapshotAnnotationPositions(): { x: number; y: number }[] {
-  return [...selectedAnnotations].map((i) => ({
-    x: annotations[i]?.x ?? 0,
-    y: annotations[i]?.y ?? 0,
-  }));
+// Snapshot the currently selected annotations' positions for a group drag,
+// keyed by annotation index (stable for the whole drag).
+function snapshotAnnotationPositions(): Map<number, { x: number; y: number }> {
+  const map = new Map<number, { x: number; y: number }>();
+  for (const i of selectedAnnotations) {
+    const a = annotations[i];
+    if (a) map.set(i, { x: a.x, y: a.y });
+  }
+  return map;
 }
 
 // Mouse down on an annotation label: select it and start dragging it (and
@@ -1582,31 +1589,34 @@ function onAnnotationMouseDown(event: MouseEvent, index: number): void {
   const anchor = annotations[index] ?? { x: 0, y: 0 };
   interaction = {
     type: "dragging",
-    anchorIndex: -1, // no node anchor; annotations move by their own delta
+    anchorIndex: -1, // no node anchor
     offsetX: svgCoords.x - anchor.x,
     offsetY: svgCoords.y - anchor.y,
     startPositions: {},
+    // The dragged annotation's index (delta base) + the snapshot of the
+    // whole annotation selection at drag start.
+    annotationAnchor: index,
     annotationStartPositions: snapshotAnnotationPositions(),
   };
 }
 
-// Move the selected annotations by the same delta as the node group drag.
+// Move every selected annotation by the same (deltaX, deltaY) from its own
+// drag-start snapshot — recomputed from the snapshot each event (like
+// applyGroupDelta), never accumulated, so there is no drift or flicker.
 function applyAnnotationDelta(deltaX: number, deltaY: number): void {
   const current = interaction;
-  if (current.type !== "dragging" || !current.annotationStartPositions) return;
+  if (current.type !== "dragging") return;
   const starts = current.annotationStartPositions;
-  const sel = [...selectedAnnotations].sort((a, b) => a - b);
-  sel.forEach((idx, k) => {
-    const start = starts[k] ??
-      { x: annotations[idx]?.x ?? 0, y: annotations[idx]?.y ?? 0 };
-    if (annotations[idx]) {
-      annotations[idx] = {
-        ...annotations[idx],
-        x: snap(start.x + deltaX),
-        y: snap(start.y + deltaY),
-      };
-    }
-  });
+  if (!starts) return;
+  for (const [idx, start] of starts) {
+    const a = annotations[idx];
+    if (!a) continue;
+    annotations[idx] = {
+      ...a,
+      x: snap(start.x + deltaX),
+      y: snap(start.y + deltaY),
+    };
+  }
 }
 
 function onCanvasMouseDown(event: MouseEvent) {
@@ -1822,13 +1832,17 @@ function onSvgMouseMove(event: MouseEvent) {
       } else if (
         current.anchorIndex === -1 && current.annotationStartPositions
       ) {
-        // Annotation-only drag: no node anchor, move by absolute pointer
-        // delta so selected annotations follow the cursor exactly.
+        // Annotation-only drag (no node anchor): compute the delta from the
+        // grabbed anchor annotation's DRAG-START snapshot (like nodes do),
+        // never from its live position, so each move is a clean delta off a
+        // fixed base — no feedback, no runaway/flicker, cursor-accurate.
         const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
-        const anchor = annotations[0] ?? { x: 0, y: 0 };
-        if (annotations[0]) {
-          const deltaX = svgCoords.x - current.offsetX - anchor.x;
-          const deltaY = svgCoords.y - current.offsetY - anchor.y;
+        const anchorStart = current.annotationStartPositions.get(
+          current.annotationAnchor ?? -1,
+        );
+        if (anchorStart) {
+          const deltaX = svgCoords.x - current.offsetX - anchorStart.x;
+          const deltaY = svgCoords.y - current.offsetY - anchorStart.y;
           applyAnnotationDelta(deltaX, deltaY);
         }
       }

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -3086,9 +3086,15 @@ $effect(() => {
         {/each}
 
         <!-- Free-standing text annotations, rendered at absolute positions.
-             Selectable + draggable like nodes; double-click to edit text. -->
+             Selectable + draggable like nodes; double-click to edit text.
+             The text itself is pointer-events: none; an invisible rect behind
+             it is the actual hit target (SVG <g> has no geometry of its own,
+             so without it the whole annotation is invisible to the mouse). -->
         {#each annotations as ann, i (`${i}-${ann.text}-${ann.x}-${ann.y}`)}
           {@const isAnnSelected = selectedAnnotations.has(i)}
+          {@const annLines = ann.text.split("\n")}
+          {@const annWidth = Math.max(...annLines.map((l) => l.length * 7.5 + 14), 40)}
+          {@const annHeight = annLines.length * 16 + 8}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <g
             class="cursor-grab"
@@ -3099,6 +3105,14 @@ $effect(() => {
               editingAnnotation = i;
             }}
           >
+            <rect
+              x={ann.x - 4}
+              y={ann.y - 16}
+              width={annWidth}
+              height={annHeight}
+              fill="transparent"
+              style="cursor: grab"
+            />
             {#if editingAnnotation === i}
               <text
                 x={ann.x}

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -436,7 +436,9 @@ $effect(() => {
     console.log(
       `[PERSIST] load       RESOLVED path=${path} editedDuringLoad=${editedDuringLoad} ` +
         `stampNow=${diagramEditStamp} fileAnnotations=${fileAnnCount} ` +
-        `fileTexts=${JSON.stringify((layout.annotations ?? []).map((a) => a.text))} ` +
+        `fileTexts=${
+          JSON.stringify((layout.annotations ?? []).map((a) => a.text))
+        } ` +
         `apply=${!editedDuringLoad}`,
     );
     if (!editedDuringLoad) {
@@ -478,10 +480,14 @@ $effect(() => {
     `[PERSIST] save       FIRED path=${path} loaded=${diagramLayoutLoaded} ` +
       `checked=${Object.keys(snapshot.checked).length} ` +
       `annotations=${annCount} ` +
-      `texts=${JSON.stringify((snapshot.annotations ?? []).map((a) => a.text))}`,
+      `texts=${
+        JSON.stringify((snapshot.annotations ?? []).map((a) => a.text))
+      }`,
   );
   if (!diagramLayoutLoaded || path === null) {
-    console.log(`[PERSIST] save       SKIPPED (loaded=${diagramLayoutLoaded} path=${path})`);
+    console.log(
+      `[PERSIST] save       SKIPPED (loaded=${diagramLayoutLoaded} path=${path})`,
+    );
     return;
   }
   void writeDiagramLayoutFile(fs, path, snapshot, systems[0]?.label || "");

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -389,8 +389,12 @@ let diagramEditStamp = 0;
 let loadStartStamp = 0;
 
 // Called by every user-diagram mutation path so the load race guard works.
-function noteDiagramEdited(): void {
+// `reason` is purely diagnostic (temporary [PERSIST] tracing).
+function noteDiagramEdited(reason: string): void {
   diagramEditStamp += 1;
+  console.log(
+    `[PERSIST] edit      #${diagramEditStamp} ${reason} annotationsInMemory=${annotations.length}`,
+  );
 }
 
 $effect(() => {
@@ -399,6 +403,10 @@ $effect(() => {
   loadedDiagramPath = path;
   diagramLayoutLoaded = false;
   loadStartStamp = diagramEditStamp;
+  console.log(
+    `[PERSIST] load       START path=${path} stampAtStart=${loadStartStamp} ` +
+      `annotationsInMemory=${annotations.length}`,
+  );
 
   if (path === null) {
     checked = {};
@@ -412,12 +420,24 @@ $effect(() => {
     // A stale load (e.g. rapid switching between diagrams) could resolve
     // after a newer one already changed the selection — guard against
     // overwriting the newer selection's state with the older one.
-    if (loadedDiagramPath !== path) return;
+    if (loadedDiagramPath !== path) {
+      console.log(
+        `[PERSIST] load       DISCARDED stale resolve (expects ${path}, now ${loadedDiagramPath})`,
+      );
+      return;
+    }
     // If the user edited the diagram while this read was in flight, don't
     // clobber their changes with the (possibly empty) file contents — but
     // still mark the diagram as loaded so the save effect is armed and can
     // persist the user's edits.
     const editedDuringLoad = diagramEditStamp !== loadStartStamp;
+    const fileAnnCount = layout.annotations?.length ?? 0;
+    console.log(
+      `[PERSIST] load       RESOLVED path=${path} editedDuringLoad=${editedDuringLoad} ` +
+        `stampNow=${diagramEditStamp} fileAnnotations=${fileAnnCount} ` +
+        `fileTexts=${JSON.stringify((layout.annotations ?? []).map((a) => a.text))} ` +
+        `apply=${!editedDuringLoad}`,
+    );
     if (!editedDuringLoad) {
       checked = layout.checked;
       savedLayout = layout.savedLayout;
@@ -452,7 +472,17 @@ $effect(() => {
     annotations: $state.snapshot(annotations),
   };
   const path = fullDiagramPath;
-  if (!diagramLayoutLoaded || path === null) return;
+  const annCount = snapshot.annotations?.length ?? 0;
+  console.log(
+    `[PERSIST] save       FIRED path=${path} loaded=${diagramLayoutLoaded} ` +
+      `checked=${Object.keys(snapshot.checked).length} ` +
+      `annotations=${annCount} ` +
+      `texts=${JSON.stringify((snapshot.annotations ?? []).map((a) => a.text))}`,
+  );
+  if (!diagramLayoutLoaded || path === null) {
+    console.log(`[PERSIST] save       SKIPPED (loaded=${diagramLayoutLoaded} path=${path})`);
+    return;
+  }
   void writeDiagramLayoutFile(fs, path, snapshot, systems[0]?.label || "");
 });
 
@@ -551,7 +581,7 @@ async function handleDeleteDiagram(path: string): Promise<void> {
 // keeps the remembered layout up to date, instead of relying on each call
 // site to remember to mirror the write itself.
 function setNodeBox(index: number, box: Partial<StoredBox>) {
-  noteDiagramEdited();
+  noteDiagramEdited("node box");
   const key = getComponentKey(index);
   const checkedPrev = checked[key];
   const savedPrev = savedLayout[key];
@@ -731,7 +761,7 @@ function selectAnnotation(index: number) {
 }
 
 function addAnnotationHandler(): void {
-  noteDiagramEdited();
+  noteDiagramEdited("annotation add");
   // Place at the canvas center (world coords) if we can, else 0,0.
   const x = editor_state.view.x + canvas_width / 2 / editor_state.view.zoom;
   const y = editor_state.view.y + canvas_height / 2 / editor_state.view.zoom;
@@ -743,7 +773,7 @@ function addAnnotationHandler(): void {
 
 function deleteSelectedAnnotations(): void {
   if (selectedAnnotations.size === 0) return;
-  noteDiagramEdited();
+  noteDiagramEdited("annotation delete");
   const toDelete = [...selectedAnnotations].sort((a, b) => b - a);
   for (const idx of toDelete) annotations.splice(idx, 1);
   selectedAnnotations.clear();
@@ -1635,7 +1665,7 @@ function onAnnotationMouseDown(event: MouseEvent, index: number): void {
 // drag-start snapshot — recomputed from the snapshot each event (like
 // applyGroupDelta), never accumulated, so there is no drift or flicker.
 function applyAnnotationDelta(deltaX: number, deltaY: number): void {
-  noteDiagramEdited();
+  noteDiagramEdited("annotation drag");
   const current = interaction;
   if (current.type !== "dragging") return;
   const starts = current.annotationStartPositions;
@@ -1794,7 +1824,7 @@ function applyGroupDelta(
   deltaX: number,
   deltaY: number,
 ) {
-  noteDiagramEdited();
+  noteDiagramEdited("node group drag");
   for (const [indexStr, start] of Object.entries(startPositions)) {
     const index = Number(indexStr);
     const box = nodeBox(index);
@@ -3345,7 +3375,7 @@ $effect(() => {
           onkeydown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              noteDiagramEdited();
+              noteDiagramEdited("annotation text edit");
               editingAnnotation = null;
             }
             if (e.key === "Escape") {
@@ -3353,7 +3383,7 @@ $effect(() => {
             }
           }}
           onblur={() => {
-            noteDiagramEdited();
+            noteDiagramEdited("annotation text edit (blur)");
             editingAnnotation = null;
           }}
           class="absolute z-30 input input-sm input-bordered w-64"

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -390,12 +390,8 @@ let diagramEditStamp = 0;
 let loadStartStamp = 0;
 
 // Called by every user-diagram mutation path so the load race guard works.
-// `reason` is purely diagnostic (temporary [PERSIST] tracing).
-function noteDiagramEdited(reason: string): void {
+function noteDiagramEdited(): void {
   diagramEditStamp += 1;
-  console.log(
-    `[PERSIST] edit      #${diagramEditStamp} ${reason} annotationsInMemory=${annotations.length}`,
-  );
 }
 
 $effect(() => {
@@ -404,10 +400,6 @@ $effect(() => {
   loadedDiagramPath = path;
   diagramLayoutLoaded = false;
   loadStartStamp = diagramEditStamp;
-  console.log(
-    `[PERSIST] load       START path=${path} stampAtStart=${loadStartStamp} ` +
-      `annotationsInMemory=${annotations.length}`,
-  );
 
   if (path === null) {
     checked = {};
@@ -421,26 +413,12 @@ $effect(() => {
     // A stale load (e.g. rapid switching between diagrams) could resolve
     // after a newer one already changed the selection — guard against
     // overwriting the newer selection's state with the older one.
-    if (loadedDiagramPath !== path) {
-      console.log(
-        `[PERSIST] load       DISCARDED stale resolve (expects ${path}, now ${loadedDiagramPath})`,
-      );
-      return;
-    }
+    if (loadedDiagramPath !== path) return;
     // If the user edited the diagram while this read was in flight, don't
     // clobber their changes with the (possibly empty) file contents — but
     // still mark the diagram as loaded so the save effect is armed and can
     // persist the user's edits.
     const editedDuringLoad = diagramEditStamp !== loadStartStamp;
-    const fileAnnCount = layout.annotations?.length ?? 0;
-    console.log(
-      `[PERSIST] load       RESOLVED path=${path} editedDuringLoad=${editedDuringLoad} ` +
-        `stampNow=${diagramEditStamp} fileAnnotations=${fileAnnCount} ` +
-        `fileTexts=${
-          JSON.stringify((layout.annotations ?? []).map((a) => a.text))
-        } ` +
-        `apply=${!editedDuringLoad}`,
-    );
     if (!editedDuringLoad) {
       checked = layout.checked;
       savedLayout = layout.savedLayout;
@@ -475,21 +453,7 @@ $effect(() => {
     annotations: $state.snapshot(annotations),
   };
   const path = fullDiagramPath;
-  const annCount = snapshot.annotations?.length ?? 0;
-  console.log(
-    `[PERSIST] save       FIRED path=${path} loaded=${diagramLayoutLoaded} ` +
-      `checked=${Object.keys(snapshot.checked).length} ` +
-      `annotations=${annCount} ` +
-      `texts=${
-        JSON.stringify((snapshot.annotations ?? []).map((a) => a.text))
-      }`,
-  );
-  if (!diagramLayoutLoaded || path === null) {
-    console.log(
-      `[PERSIST] save       SKIPPED (loaded=${diagramLayoutLoaded} path=${path})`,
-    );
-    return;
-  }
+  if (!diagramLayoutLoaded || path === null) return;
   void writeDiagramLayoutFile(fs, path, snapshot, systems[0]?.label || "");
 });
 
@@ -588,7 +552,7 @@ async function handleDeleteDiagram(path: string): Promise<void> {
 // keeps the remembered layout up to date, instead of relying on each call
 // site to remember to mirror the write itself.
 function setNodeBox(index: number, box: Partial<StoredBox>) {
-  noteDiagramEdited("node box");
+  noteDiagramEdited();
   const key = getComponentKey(index);
   const checkedPrev = checked[key];
   const savedPrev = savedLayout[key];
@@ -768,7 +732,7 @@ function selectAnnotation(index: number) {
 }
 
 function addAnnotationHandler(): void {
-  noteDiagramEdited("annotation add");
+  noteDiagramEdited();
   // Place at the canvas center (world coords) if we can, else 0,0.
   const x = editor_state.view.x + canvas_width / 2 / editor_state.view.zoom;
   const y = editor_state.view.y + canvas_height / 2 / editor_state.view.zoom;
@@ -780,7 +744,7 @@ function addAnnotationHandler(): void {
 
 function deleteSelectedAnnotations(): void {
   if (selectedAnnotations.size === 0) return;
-  noteDiagramEdited("annotation delete");
+  noteDiagramEdited();
   const toDelete = [...selectedAnnotations].sort((a, b) => b - a);
   for (const idx of toDelete) annotations.splice(idx, 1);
   selectedAnnotations.clear();
@@ -1672,7 +1636,7 @@ function onAnnotationMouseDown(event: MouseEvent, index: number): void {
 // drag-start snapshot — recomputed from the snapshot each event (like
 // applyGroupDelta), never accumulated, so there is no drift or flicker.
 function applyAnnotationDelta(deltaX: number, deltaY: number): void {
-  noteDiagramEdited("annotation drag");
+  noteDiagramEdited();
   const current = interaction;
   if (current.type !== "dragging") return;
   const starts = current.annotationStartPositions;
@@ -1831,7 +1795,7 @@ function applyGroupDelta(
   deltaX: number,
   deltaY: number,
 ) {
-  noteDiagramEdited("node group drag");
+  noteDiagramEdited();
   for (const [indexStr, start] of Object.entries(startPositions)) {
     const index = Number(indexStr);
     const box = nodeBox(index);
@@ -3379,7 +3343,7 @@ $effect(() => {
           onkeydown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              noteDiagramEdited("annotation text edit");
+              noteDiagramEdited();
               editingAnnotation = null;
             }
             if (e.key === "Escape") {
@@ -3387,7 +3351,7 @@ $effect(() => {
             }
           }}
           onblur={() => {
-            noteDiagramEdited("annotation text edit (blur)");
+            noteDiagramEdited();
             editingAnnotation = null;
           }}
           class="absolute z-30 input input-sm input-bordered w-64"

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -54,7 +54,10 @@ import {
   type LayoutNode,
 } from "./forceLayout";
 import {
+  ANNOTATION_FONT_SIZE,
+  ANNOTATION_LINE_HEIGHT,
   annotationBounds,
+  annotationLines,
   boxContains,
   clampWithin,
   computeDirectionalHandles,
@@ -3219,7 +3222,8 @@ $effect(() => {
           {@const isAnnSelected = interaction.type === "marquee"
             ? marqueeAnnotationCandidates.has(i)
             : selectedAnnotations.has(i)}
-          {@const annFontSize = 12 * (ann.scale ?? 1)}
+          {@const annFontSize = ANNOTATION_FONT_SIZE * (ann.scale ?? 1)}
+          {@const annLineStep = ANNOTATION_LINE_HEIGHT * (ann.scale ?? 1)}
           {@const annHit = annotationHitBox(ann)}
           {@const annX = annHit.x}
           {@const annY = annHit.y}
@@ -3282,7 +3286,11 @@ $effect(() => {
                 text-anchor="start"
                 style="user-select: none"
               >
-                {ann.text}
+                {#each annotationLines(ann.text) as line, li (li)}
+                  <tspan x={ann.x} dy={li === 0 ? 0 : annLineStep}>
+                    {line || '\u00a0'}
+                  </tspan>
+                {/each}
               </text>
             {:else}
               <text
@@ -3293,9 +3301,13 @@ $effect(() => {
                   : "var(--color-base-content)"}
                 font-size={annFontSize}
                 text-anchor="start"
-                style="pointer-events: none; user-select: none; white-space: pre"
+                style="pointer-events: none; user-select: none"
               >
-                {ann.text}
+                {#each annotationLines(ann.text) as line, li (li)}
+                  <tspan x={ann.x} dy={li === 0 ? 0 : annLineStep}>
+                    {line || '\u00a0'}
+                  </tspan>
+                {/each}
               </text>
             {/if}
           </g>
@@ -3337,11 +3349,13 @@ $effect(() => {
 
       {#if editingAnnotationObj}
         <!-- Inline text editor for the annotation being edited. Positioned in
-             screen space (world coords x zoom + view origin). -->
-        <input
+             screen space (world coords x zoom + view origin). Multiline:
+             plain Enter commits (matching the pre-multiline behavior),
+             Alt+Enter (or Shift/Ctrl+Enter) inserts a newline. -->
+        <textarea
           bind:value={editingAnnotationObj.text}
           onkeydown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
+            if (e.key === "Enter" && !e.altKey && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
               e.preventDefault();
               noteDiagramEdited();
               editingAnnotation = null;
@@ -3354,10 +3368,13 @@ $effect(() => {
             noteDiagramEdited();
             editingAnnotation = null;
           }}
-          class="absolute z-30 input input-sm input-bordered w-64"
+          class="absolute z-30 textarea textarea-sm textarea-bordered w-64"
+          rows={Math.max(2, annotationLines(editingAnnotationObj.text).length)}
+          placeholder="Alt+Enter for a new line"
+          title="Enter commits, Alt+Enter inserts a newline"
           style="left:{(editingAnnotationObj.x - editor_state.view.x) * editor_state.view.zoom}px; top:{(editingAnnotationObj.y - editor_state.view.y) * editor_state.view.zoom}px"
           data-testid="annotation-editor"
-        />
+        ></textarea>
       {/if}
 
       {#if !model && output.error_count() > 0}

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -3205,17 +3205,18 @@ $effect(() => {
                 stroke-dasharray={SELECTION_OUTLINE_DASHARRAY}
                 style="pointer-events: none"
               />
-              <!-- Bottom-right corner resize handle (font scale). -->
+              <!-- Top-right corner resize handle (font scale), tucked INSIDE
+                   the selection box (x/y within annX..annX+annWidth). -->
               <!-- svelte-ignore a11y_no_static_element_interactions -->
               <rect
-                x={annX + annWidth - CORNER_HANDLE_SIZE / 2}
-                y={annY + annHeight - CORNER_HANDLE_SIZE / 2}
+                x={annX + annWidth - CORNER_HANDLE_SIZE}
+                y={annY}
                 width={CORNER_HANDLE_SIZE}
                 height={CORNER_HANDLE_SIZE}
                 fill="var(--color-primary)"
                 fill-opacity="0.9"
-                style="cursor: nwse-resize"
-                onmousedown={(e) => onAnnotationResizeMouseDown(e, i, "bottom-right")}
+                style="cursor: nesw-resize"
+                onmousedown={(e) => onAnnotationResizeMouseDown(e, i, "top-right")}
               />
             {/if}
             {#if editingAnnotation === i}

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -54,6 +54,7 @@ import {
   type LayoutNode,
 } from "./forceLayout";
 import {
+  annotationBounds,
   boxContains,
   clampWithin,
   computeDirectionalHandles,
@@ -2255,18 +2256,12 @@ let marqueeCandidates: Set<number> = $derived.by(() => {
 
 // Hit-box of an annotation, matching the geometry used for rendering and
 // click hit-testing exactly (so marquee selection, the highlight state and
-// the visible box all agree).
+// the visible box all agree). Delegates to the shared annotationBounds so
+// "zoom to fill" and the static renderers can't drift from hit-testing.
 function annotationHitBox(
   ann: Annotation,
 ): { x: number; y: number; width: number; height: number } {
-  const scale = ann.scale ?? 1;
-  const lines = ann.text.split("\n");
-  const width = Math.max(
-    ...lines.map((l) => l.length * 7.5 * scale + 14),
-    40,
-  );
-  const height = lines.length * 16 * scale + 8;
-  return { x: ann.x - 4, y: ann.y - 16 * scale, width, height };
+  return annotationBounds(ann);
 }
 
 // Annotations caught by the current marquee box (live preview), parallel to
@@ -2287,15 +2282,18 @@ let marqueeAnnotationCandidates: Set<number> = $derived.by(() => {
 // "Zoom to Fill" is used.
 const ZOOM_TO_FILL_FRACTION = 0.8;
 
-// Zooms and pans so every currently-placed node's combined bounding box
-// fills ZOOM_TO_FILL_FRACTION of the viewport, centered. No-op if nothing
-// is placed on canvas.
+// Zooms and pans so every currently-placed node's AND annotation's combined
+// bounding box fills ZOOM_TO_FILL_FRACTION of the viewport, centered —
+// annotations far from the node cluster are never panned out of view.
+// No-op if nothing is placed on canvas.
 function zoomToFill() {
-  const boxes = renderOrder
+  const nodeBoxes = renderOrder
     .map((index) => nodeBox(index))
     .filter(
       (box): box is NonNullable<ReturnType<typeof nodeBox>> => box !== null,
     );
+  const annotationBoxes = annotations.map(annotationBounds);
+  const boxes = [...nodeBoxes, ...annotationBoxes];
   if (boxes.length === 0) return;
   const bounds = unionBox(boxes);
 

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -3113,6 +3113,23 @@ $effect(() => {
               fill="transparent"
               style="cursor: grab"
             />
+            {#if isAnnSelected}
+              <!-- Selection frame identical in style to components: a dotted
+                   primary outline around the annotation's hit box. -->
+              <rect
+                x={ann.x - 4}
+                y={ann.y - 16}
+                width={annWidth}
+                height={annHeight}
+                rx="3"
+                fill="none"
+                stroke="var(--color-primary)"
+                stroke-opacity={SELECTION_OUTLINE_OPACITY}
+                stroke-width="1.5"
+                stroke-dasharray={SELECTION_OUTLINE_DASHARRAY}
+                style="pointer-events: none"
+              />
+            {/if}
             {#if editingAnnotation === i}
               <text
                 x={ann.x}

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -976,7 +976,7 @@ type Interaction =
     offsetY: number;
     startPositions: Record<number, { x: number; y: number }>;
     /** Selected annotations' start positions (absolute), keyed by index, moved alongside nodes. */
-    annotationStartPositions?: Map<number, { x: number; y: number }>;
+    annotationStartPositions?: Record<number, { x: number; y: number }>;
     /** The annotation index grabbed to start an annotation-only drag (delta base). */
     annotationAnchor?: number;
   }
@@ -989,6 +989,8 @@ type Interaction =
     startPointer: { x: number; y: number };
     groupBox: Box;
     startBoxes: Record<number, Box>;
+    /** When set, this is an annotation resize: index into annotations + its start scale. */
+    annotationResize?: { index: number; startScale: number };
   }
   | {
     // Canvas pan. Started by the middle mouse button, or the left
@@ -1559,11 +1561,14 @@ function onNodeMouseDown(event: MouseEvent, index: number) {
 
 // Snapshot the currently selected annotations' positions for a group drag,
 // keyed by annotation index (stable for the whole drag).
-function snapshotAnnotationPositions(): Map<number, { x: number; y: number }> {
-  const map = new Map<number, { x: number; y: number }>();
+function snapshotAnnotationPositions(): Record<
+  number,
+  { x: number; y: number }
+> {
+  const map: Record<number, { x: number; y: number }> = {};
   for (const i of selectedAnnotations) {
     const a = annotations[i];
-    if (a) map.set(i, { x: a.x, y: a.y });
+    if (a) map[i] = { x: a.x, y: a.y };
   }
   return map;
 }
@@ -1612,15 +1617,47 @@ function applyAnnotationDelta(deltaX: number, deltaY: number): void {
   if (current.type !== "dragging") return;
   const starts = current.annotationStartPositions;
   if (!starts) return;
-  for (const [idx, start] of starts) {
+  for (const idxStr of Object.keys(starts)) {
+    const idx = Number(idxStr);
+    const start = starts[idx];
     const a = annotations[idx];
-    if (!a) continue;
+    if (!a || !start) continue;
     annotations[idx] = {
       ...a,
       x: snap(start.x + deltaX),
       y: snap(start.y + deltaY),
     };
   }
+}
+
+// Start resizing a selected annotation from one of its corner handles.
+// The drag changes the annotation's `scale` (100% = 1.0) — corner-pull
+// distance scales the font multiplier, mirroring how node resize handles
+// work but as a pure scale factor instead of a box.
+function onAnnotationResizeMouseDown(
+  event: MouseEvent,
+  index: number,
+  handle: ResizeHandle,
+): void {
+  event.stopPropagation();
+  if (autoLayoutRunning) return;
+  if (event.button !== 0) return;
+  event.preventDefault();
+  if (!selectedAnnotations.has(index)) selectAnnotation(index);
+  recordUndoPoint();
+  const a = annotations[index];
+  if (!a) return;
+  const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
+  interaction = {
+    type: "resizing",
+    anchorIndex: -1,
+    handle,
+    startBox: { x: a.x, y: a.y, width: 0, height: 0 },
+    startPointer: svgCoords,
+    groupBox: { x: a.x, y: a.y, width: 0, height: 0 },
+    startBoxes: {},
+    annotationResize: { index, startScale: a.scale ?? 1 },
+  };
 }
 
 function onCanvasMouseDown(event: MouseEvent) {
@@ -1841,9 +1878,9 @@ function onSvgMouseMove(event: MouseEvent) {
         // never from its live position, so each move is a clean delta off a
         // fixed base — no feedback, no runaway/flicker, cursor-accurate.
         const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
-        const anchorStart = current.annotationStartPositions.get(
-          current.annotationAnchor ?? -1,
-        );
+        const anchorStart = current.annotationStartPositions[
+          current.annotationAnchor ?? -1
+        ];
         if (anchorStart) {
           const deltaX = svgCoords.x - current.offsetX - anchorStart.x;
           const deltaY = svgCoords.y - current.offsetY - anchorStart.y;
@@ -1853,6 +1890,24 @@ function onSvgMouseMove(event: MouseEvent) {
       return;
     }
     case "resizing": {
+      if (current.annotationResize) {
+        // Annotation resize: the corner drag maps (deltaX, deltaY) to a new
+        // font scale — startScale + fractional distance. A minimum guard
+        // keeps the note from collapsing to nothing.
+        const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
+        const deltaX = svgCoords.x - current.startPointer.x;
+        const deltaY = svgCoords.y - current.startPointer.y;
+        const a = annotations[current.annotationResize.index];
+        if (a) {
+          const start = current.annotationResize.startScale;
+          const scale = Math.max(0.5, start + (deltaX + deltaY) / 100);
+          annotations[current.annotationResize.index] = {
+            ...a,
+            scale,
+          };
+        }
+        return;
+      }
       const anchorStart = current.startBox;
       if (anchorStart) {
         const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
@@ -3104,15 +3159,18 @@ $effect(() => {
         {/each}
 
         <!-- Free-standing text annotations, rendered at absolute positions.
-             Selectable + draggable like nodes; double-click to edit text.
-             The text itself is pointer-events: none; an invisible rect behind
-             it is the actual hit target (SVG <g> has no geometry of its own,
-             so without it the whole annotation is invisible to the mouse). -->
-        {#each annotations as ann, i (`${i}-${ann.text}-${ann.x}-${ann.y}`)}
+             Selectable + draggable like nodes; double-click to edit text;
+             corner-drag to resize (changes the font scale). The text itself
+             is pointer-events: none; an invisible rect behind it is the hit
+             target (SVG <g> has no geometry of its own). -->
+        {#each annotations as ann, i (`${i}-${ann.text}-${ann.x}-${ann.y}-${ann.scale}`)}
           {@const isAnnSelected = selectedAnnotations.has(i)}
+          {@const annFontSize = 12 * (ann.scale ?? 1)}
           {@const annLines = ann.text.split("\n")}
-          {@const annWidth = Math.max(...annLines.map((l) => l.length * 7.5 + 14), 40)}
-          {@const annHeight = annLines.length * 16 + 8}
+          {@const annWidth = Math.max(...annLines.map((l) => l.length * 7.5 * (ann.scale ?? 1) + 14), 40)}
+          {@const annHeight = annLines.length * 16 * (ann.scale ?? 1) + 8}
+          {@const annX = ann.x - 4}
+          {@const annY = ann.y - 16 * (ann.scale ?? 1)}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <g
             class="cursor-grab"
@@ -3124,8 +3182,8 @@ $effect(() => {
             }}
           >
             <rect
-              x={ann.x - 4}
-              y={ann.y - 16}
+              x={annX}
+              y={annY}
               width={annWidth}
               height={annHeight}
               fill="transparent"
@@ -3135,8 +3193,8 @@ $effect(() => {
               <!-- Selection frame identical in style to components: a dotted
                    primary outline around the annotation's hit box. -->
               <rect
-                x={ann.x - 4}
-                y={ann.y - 16}
+                x={annX}
+                y={annY}
                 width={annWidth}
                 height={annHeight}
                 rx="3"
@@ -3147,13 +3205,25 @@ $effect(() => {
                 stroke-dasharray={SELECTION_OUTLINE_DASHARRAY}
                 style="pointer-events: none"
               />
+              <!-- Bottom-right corner resize handle (font scale). -->
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
+              <rect
+                x={annX + annWidth - CORNER_HANDLE_SIZE / 2}
+                y={annY + annHeight - CORNER_HANDLE_SIZE / 2}
+                width={CORNER_HANDLE_SIZE}
+                height={CORNER_HANDLE_SIZE}
+                fill="var(--color-primary)"
+                fill-opacity="0.9"
+                style="cursor: nwse-resize"
+                onmousedown={(e) => onAnnotationResizeMouseDown(e, i, "bottom-right")}
+              />
             {/if}
             {#if editingAnnotation === i}
               <text
                 x={ann.x}
                 y={ann.y}
                 fill="var(--color-primary)"
-                font-size="12"
+                font-size={annFontSize}
                 text-anchor="start"
                 style="user-select: none"
               >
@@ -3166,7 +3236,7 @@ $effect(() => {
                 fill={isAnnSelected
                   ? "var(--color-primary)"
                   : "var(--color-base-content)"}
-                font-size="12"
+                font-size={annFontSize}
                 text-anchor="start"
                 style="pointer-events: none; user-select: none; white-space: pre"
               >

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -30,6 +30,7 @@ import {
 } from "../../../../DocumentStore.svelte";
 
 import {
+  type Annotation,
   buildKeyToIndexMap,
   componentKey,
   DIAGRAM_LAYOUT_DIR,
@@ -281,6 +282,7 @@ let checked = $state<Record<string, StoredBox>>({});
 // different lifetimes (checked entries disappear on uncheck; these don't).
 let savedLayout = $state<Record<string, StoredBox>>({});
 let savedConnections = $state<Record<string, StoredConnection>>({});
+let annotations = $state<Annotation[]>([]);
 
 // Which diagram (a `diagrams/<name>.hcl` file) is currently open on the
 // canvas, relative to DIAGRAM_LAYOUT_DIR — e.g. "main.hcl" — exactly like
@@ -380,6 +382,7 @@ $effect(() => {
     checked = {};
     savedLayout = {};
     savedConnections = {};
+    annotations = [];
     return;
   }
 
@@ -391,6 +394,7 @@ $effect(() => {
     checked = layout.checked;
     savedLayout = layout.savedLayout;
     savedConnections = layout.connections ?? {};
+    annotations = layout.annotations ?? [];
     diagramLayoutLoaded = true;
     // Frames the newly-opened diagram's content immediately, rather than
     // leaving the view wherever the previously-open diagram (or the
@@ -416,6 +420,7 @@ $effect(() => {
     checked: $state.snapshot(checked),
     savedLayout: $state.snapshot(savedLayout),
     connections: $state.snapshot(savedConnections),
+    annotations: $state.snapshot(annotations),
   };
   const path = fullDiagramPath;
   if (!diagramLayoutLoaded || path === null) return;

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -695,6 +695,7 @@ let selected = $derived.by(() => {
 
 function selectOnly(index: number) {
   selectedKeys.clear();
+  selectedAnnotations.clear();
   selectedKeys.add(getComponentKey(index));
 }
 
@@ -731,6 +732,9 @@ function deselect(index: number) {
 }
 
 function select(index: number) {
+  // Selecting a node drops annotation selection: the two selection modes
+  // are mutually exclusive (mirrors selectAnnotation clearing node keys).
+  selectedAnnotations.clear();
   selectedKeys.add(getComponentKey(index));
 }
 

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -3166,7 +3166,6 @@ $effect(() => {
                 fill={isAnnSelected
                   ? "var(--color-primary)"
                   : "var(--color-base-content)"}
-                fill-opacity={isAnnSelected ? 1 : 0.7}
                 font-size="12"
                 text-anchor="start"
                 style="pointer-events: none; user-select: none; white-space: pre"

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -381,12 +381,24 @@ $effect(() => {
 // layout.
 let diagramLayoutLoaded = $state(false);
 let loadedDiagramPath: string | null = null;
+// Monotonic stamp bumped on any user diagram mutation (adding/moving a node,
+// editing an annotation). The load effect records the stamp when a read
+// starts and only applies the result if no mutation happened in the meantime
+// — so a slow read can never clobber edits made while it was in flight.
+let diagramEditStamp = 0;
+let loadStartStamp = 0;
+
+// Called by every user-diagram mutation path so the load race guard works.
+function noteDiagramEdited(): void {
+  diagramEditStamp += 1;
+}
 
 $effect(() => {
   const path = fullDiagramPath;
   if (path === loadedDiagramPath) return;
   loadedDiagramPath = path;
   diagramLayoutLoaded = false;
+  loadStartStamp = diagramEditStamp;
 
   if (path === null) {
     checked = {};
@@ -401,10 +413,17 @@ $effect(() => {
     // after a newer one already changed the selection — guard against
     // overwriting the newer selection's state with the older one.
     if (loadedDiagramPath !== path) return;
-    checked = layout.checked;
-    savedLayout = layout.savedLayout;
-    savedConnections = layout.connections ?? {};
-    annotations = layout.annotations ?? [];
+    // If the user edited the diagram while this read was in flight, don't
+    // clobber their changes with the (possibly empty) file contents — but
+    // still mark the diagram as loaded so the save effect is armed and can
+    // persist the user's edits.
+    const editedDuringLoad = diagramEditStamp !== loadStartStamp;
+    if (!editedDuringLoad) {
+      checked = layout.checked;
+      savedLayout = layout.savedLayout;
+      savedConnections = layout.connections ?? {};
+      annotations = layout.annotations ?? [];
+    }
     diagramLayoutLoaded = true;
     // Frames the newly-opened diagram's content immediately, rather than
     // leaving the view wherever the previously-open diagram (or the
@@ -532,6 +551,7 @@ async function handleDeleteDiagram(path: string): Promise<void> {
 // keeps the remembered layout up to date, instead of relying on each call
 // site to remember to mirror the write itself.
 function setNodeBox(index: number, box: Partial<StoredBox>) {
+  noteDiagramEdited();
   const key = getComponentKey(index);
   const checkedPrev = checked[key];
   const savedPrev = savedLayout[key];
@@ -711,6 +731,7 @@ function selectAnnotation(index: number) {
 }
 
 function addAnnotationHandler(): void {
+  noteDiagramEdited();
   // Place at the canvas center (world coords) if we can, else 0,0.
   const x = editor_state.view.x + canvas_width / 2 / editor_state.view.zoom;
   const y = editor_state.view.y + canvas_height / 2 / editor_state.view.zoom;
@@ -722,6 +743,7 @@ function addAnnotationHandler(): void {
 
 function deleteSelectedAnnotations(): void {
   if (selectedAnnotations.size === 0) return;
+  noteDiagramEdited();
   const toDelete = [...selectedAnnotations].sort((a, b) => b - a);
   for (const idx of toDelete) annotations.splice(idx, 1);
   selectedAnnotations.clear();
@@ -1613,6 +1635,7 @@ function onAnnotationMouseDown(event: MouseEvent, index: number): void {
 // drag-start snapshot — recomputed from the snapshot each event (like
 // applyGroupDelta), never accumulated, so there is no drift or flicker.
 function applyAnnotationDelta(deltaX: number, deltaY: number): void {
+  noteDiagramEdited();
   const current = interaction;
   if (current.type !== "dragging") return;
   const starts = current.annotationStartPositions;
@@ -1771,6 +1794,7 @@ function applyGroupDelta(
   deltaX: number,
   deltaY: number,
 ) {
+  noteDiagramEdited();
   for (const [indexStr, start] of Object.entries(startPositions)) {
     const index = Number(indexStr);
     const box = nodeBox(index);
@@ -3289,13 +3313,17 @@ $effect(() => {
           onkeydown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
+              noteDiagramEdited();
               editingAnnotation = null;
             }
             if (e.key === "Escape") {
               editingAnnotation = null;
             }
           }}
-          onblur={() => (editingAnnotation = null)}
+          onblur={() => {
+            noteDiagramEdited();
+            editingAnnotation = null;
+          }}
           class="absolute z-30 input input-sm input-bordered w-64"
           style="left:{(editingAnnotationObj.x - editor_state.view.x) * editor_state.view.zoom}px; top:{(editingAnnotationObj.y - editor_state.view.y) * editor_state.view.zoom}px"
           data-testid="annotation-editor"

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -3168,7 +3168,6 @@ $effect(() => {
                   : "var(--color-base-content)"}
                 fill-opacity={isAnnSelected ? 1 : 0.7}
                 font-size="12"
-                font-weight={isAnnSelected ? "bold" : "normal"}
                 text-anchor="start"
                 style="pointer-events: none; user-select: none; white-space: pre"
               >

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -283,6 +283,14 @@ let checked = $state<Record<string, StoredBox>>({});
 let savedLayout = $state<Record<string, StoredBox>>({});
 let savedConnections = $state<Record<string, StoredConnection>>({});
 let annotations = $state<Annotation[]>([]);
+// Indices into `annotations` currently selected (for drag/delete).
+let selectedAnnotations = $state<Set<number>>(new Set());
+// When editing an annotation's text inline (index, or null when not editing).
+let editingAnnotation = $state<number | null>(null);
+// The annotation object currently being edited (undefined when not editing).
+let editingAnnotationObj = $derived(
+  editingAnnotation === null ? undefined : annotations[editingAnnotation],
+);
 
 // Which diagram (a `diagrams/<name>.hcl` file) is currently open on the
 // canvas, relative to DIAGRAM_LAYOUT_DIR — e.g. "main.hcl" — exactly like
@@ -690,6 +698,30 @@ function selectOnly(index: number) {
 
 function clearSelection() {
   selectedKeys.clear();
+  selectedAnnotations.clear();
+}
+
+function selectAnnotation(index: number) {
+  selectedAnnotations.clear();
+  selectedKeys.clear();
+  selectedAnnotations.add(index);
+}
+
+function addAnnotationHandler(): void {
+  // Place at the canvas center (world coords) if we can, else 0,0.
+  const x = editor_state.view.x + canvas_width / 2 / editor_state.view.zoom;
+  const y = editor_state.view.y + canvas_height / 2 / editor_state.view.zoom;
+  const idx = annotations.length;
+  annotations.push({ text: "New note", x, y });
+  selectAnnotation(idx);
+  editingAnnotation = idx;
+}
+
+function deleteSelectedAnnotations(): void {
+  if (selectedAnnotations.size === 0) return;
+  const toDelete = [...selectedAnnotations].sort((a, b) => b - a);
+  for (const idx of toDelete) annotations.splice(idx, 1);
+  selectedAnnotations.clear();
 }
 
 function deselect(index: number) {
@@ -803,12 +835,14 @@ function onDiagramKeyDown(event: KeyboardEvent) {
     }
   }
 
-  // Delete key: delete the selected connection, or the selected component.
-  // Only fires when the canvas is focused (so it never triggers while typing
-  // in the inspector or HCL editor).
+  // Delete key: delete the selected connection, selected annotation, or the
+  // selected component. Only fires when the canvas is focused (so it never
+  // triggers while typing in the inspector or HCL editor).
   if (canvasFocused && (event.key === "Delete" || event.key === "Backspace")) {
     event.preventDefault();
-    if (selectedConnection) {
+    if (selectedAnnotations.size > 0) {
+      deleteSelectedAnnotations();
+    } else if (selectedConnection) {
       void handleDeleteSelectedConnection(true).catch(reportDiagramError);
     } else if (selectedKey) {
       void handleDeleteSelectedComponent().catch(reportDiagramError);
@@ -935,6 +969,8 @@ type Interaction =
     offsetX: number;
     offsetY: number;
     startPositions: Record<number, { x: number; y: number }>;
+    /** Selected annotations' start positions (absolute), moved alongside nodes. */
+    annotationStartPositions?: { x: number; y: number }[];
   }
   | {
     // Resizing any node via any of its 8 edge/corner handles.
@@ -1509,7 +1545,68 @@ function onNodeMouseDown(event: MouseEvent, index: number) {
     offsetX: svgCoords.x - anchorStart.x,
     offsetY: svgCoords.y - anchorStart.y,
     startPositions,
+    annotationStartPositions: snapshotAnnotationPositions(),
   };
+}
+
+// Snapshot the currently selected annotations' positions for a group drag.
+function snapshotAnnotationPositions(): { x: number; y: number }[] {
+  return [...selectedAnnotations].map((i) => ({
+    x: annotations[i]?.x ?? 0,
+    y: annotations[i]?.y ?? 0,
+  }));
+}
+
+// Mouse down on an annotation label: select it and start dragging it (and
+// any other selected annotations) with the same interaction as nodes.
+function onAnnotationMouseDown(event: MouseEvent, index: number): void {
+  event.stopPropagation();
+  selectedConnection = null;
+  if (autoLayoutRunning) return;
+  if (event.button !== 0) return;
+  event.preventDefault();
+  recordUndoPoint();
+
+  if (event.shiftKey) {
+    if (selectedAnnotations.has(index)) {
+      selectedAnnotations.delete(index);
+    } else {
+      selectedAnnotations.add(index);
+    }
+    selectedKeys.clear();
+  } else if (!selectedAnnotations.has(index)) {
+    selectAnnotation(index);
+  }
+
+  const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
+  const anchor = annotations[index] ?? { x: 0, y: 0 };
+  interaction = {
+    type: "dragging",
+    anchorIndex: -1, // no node anchor; annotations move by their own delta
+    offsetX: svgCoords.x - anchor.x,
+    offsetY: svgCoords.y - anchor.y,
+    startPositions: {},
+    annotationStartPositions: snapshotAnnotationPositions(),
+  };
+}
+
+// Move the selected annotations by the same delta as the node group drag.
+function applyAnnotationDelta(deltaX: number, deltaY: number): void {
+  const current = interaction;
+  if (current.type !== "dragging" || !current.annotationStartPositions) return;
+  const starts = current.annotationStartPositions;
+  const sel = [...selectedAnnotations].sort((a, b) => a - b);
+  sel.forEach((idx, k) => {
+    const start = starts[k] ??
+      { x: annotations[idx]?.x ?? 0, y: annotations[idx]?.y ?? 0 };
+    if (annotations[idx]) {
+      annotations[idx] = {
+        ...annotations[idx],
+        x: snap(start.x + deltaX),
+        y: snap(start.y + deltaY),
+      };
+    }
+  });
 }
 
 function onCanvasMouseDown(event: MouseEvent) {
@@ -1693,6 +1790,7 @@ function onSvgMouseMove(event: MouseEvent) {
         const deltaX = anchorNext.x - anchorStart.x;
         const deltaY = anchorNext.y - anchorStart.y;
         applyGroupDelta(current.startPositions, deltaX, deltaY);
+        applyAnnotationDelta(deltaX, deltaY);
 
         // Check potential drop/reparent target candidate only if Alt is held
         if (event.altKey) {
@@ -1720,6 +1818,18 @@ function onSvgMouseMove(event: MouseEvent) {
           }
         } else {
           reparentTargetIndex = null;
+        }
+      } else if (
+        current.anchorIndex === -1 && current.annotationStartPositions
+      ) {
+        // Annotation-only drag: no node anchor, move by absolute pointer
+        // delta so selected annotations follow the cursor exactly.
+        const svgCoords = svgPoint(root_svg, event.clientX, event.clientY);
+        const anchor = annotations[0] ?? { x: 0, y: 0 };
+        if (annotations[0]) {
+          const deltaX = svgCoords.x - current.offsetX - anchor.x;
+          const deltaY = svgCoords.y - current.offsetY - anchor.y;
+          applyAnnotationDelta(deltaX, deltaY);
         }
       }
       return;
@@ -2975,6 +3085,50 @@ $effect(() => {
           </g>
         {/each}
 
+        <!-- Free-standing text annotations, rendered at absolute positions.
+             Selectable + draggable like nodes; double-click to edit text. -->
+        {#each annotations as ann, i (`${i}-${ann.text}-${ann.x}-${ann.y}`)}
+          {@const isAnnSelected = selectedAnnotations.has(i)}
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <g
+            class="cursor-grab"
+            onmousedown={(e) => onAnnotationMouseDown(e, i)}
+            ondblclick={(e) => {
+              e.stopPropagation();
+              selectAnnotation(i);
+              editingAnnotation = i;
+            }}
+          >
+            {#if editingAnnotation === i}
+              <text
+                x={ann.x}
+                y={ann.y}
+                fill="var(--color-primary)"
+                font-size="12"
+                text-anchor="start"
+                style="user-select: none"
+              >
+                {ann.text}
+              </text>
+            {:else}
+              <text
+                x={ann.x}
+                y={ann.y}
+                fill={isAnnSelected
+                  ? "var(--color-primary)"
+                  : "var(--color-base-content)"}
+                fill-opacity={isAnnSelected ? 1 : 0.7}
+                font-size="12"
+                font-weight={isAnnSelected ? "bold" : "normal"}
+                text-anchor="start"
+                style="pointer-events: none; user-select: none; white-space: pre"
+              >
+                {ann.text}
+              </text>
+            {/if}
+          </g>
+        {/each}
+
         {#if interaction.type === "connecting"}
           <path
             d={elbowPath(
@@ -3008,6 +3162,27 @@ $effect(() => {
           />
         {/if}
       </svg>
+
+      {#if editingAnnotationObj}
+        <!-- Inline text editor for the annotation being edited. Positioned in
+             screen space (world coords x zoom + view origin). -->
+        <input
+          bind:value={editingAnnotationObj.text}
+          onkeydown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              editingAnnotation = null;
+            }
+            if (e.key === "Escape") {
+              editingAnnotation = null;
+            }
+          }}
+          onblur={() => (editingAnnotation = null)}
+          class="absolute z-30 input input-sm input-bordered w-64"
+          style="left:{(editingAnnotationObj.x - editor_state.view.x) * editor_state.view.zoom}px; top:{(editingAnnotationObj.y - editor_state.view.y) * editor_state.view.zoom}px"
+          data-testid="annotation-editor"
+        />
+      {/if}
 
       {#if !model && output.error_count() > 0}
         <div
@@ -3056,6 +3231,7 @@ $effect(() => {
         onresetview={() => reset_view(editor_state)}
         onaddsystem={() => void handleAddSystem().catch(reportDiagramError)}
         onaddcomponent={() => openCreateComponentModal()}
+        onaddannotation={() => addAnnotationHandler()}
       />
 
       <div

--- a/web/src/routes/projects/[id]/diagrams/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/+page.svelte
@@ -2033,6 +2033,7 @@ function onSvgMouseUp() {
     clearSelection();
     if (box && (box.width > 2 || box.height > 2)) {
       for (const index of marqueeCandidates) select(index);
+      for (const i of marqueeAnnotationCandidates) selectedAnnotations.add(i);
     }
   }
   interaction = { type: "idle" };
@@ -2219,6 +2220,35 @@ let marqueeCandidates: Set<number> = $derived.by(() => {
     const box2 = nodeBox(index);
     if (box2 && boxContains(box, box2)) candidates.add(index);
   }
+  return candidates;
+});
+
+// Hit-box of an annotation, matching the geometry used for rendering and
+// click hit-testing exactly (so marquee selection, the highlight state and
+// the visible box all agree).
+function annotationHitBox(
+  ann: Annotation,
+): { x: number; y: number; width: number; height: number } {
+  const scale = ann.scale ?? 1;
+  const lines = ann.text.split("\n");
+  const width = Math.max(
+    ...lines.map((l) => l.length * 7.5 * scale + 14),
+    40,
+  );
+  const height = lines.length * 16 * scale + 8;
+  return { x: ann.x - 4, y: ann.y - 16 * scale, width, height };
+}
+
+// Annotations caught by the current marquee box (live preview), parallel to
+// marqueeCandidates for nodes.
+let marqueeAnnotationCandidates: Set<number> = $derived.by(() => {
+  if (!marqueeBox) return new Set();
+  const box = marqueeBox;
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const candidates = new Set<number>();
+  annotations.forEach((ann, i) => {
+    if (boxContains(box, annotationHitBox(ann))) candidates.add(i);
+  });
   return candidates;
 });
 
@@ -3188,13 +3218,15 @@ $effect(() => {
              is pointer-events: none; an invisible rect behind it is the hit
              target (SVG <g> has no geometry of its own). -->
         {#each annotations as ann, i (`${i}-${ann.text}-${ann.x}-${ann.y}-${ann.scale}`)}
-          {@const isAnnSelected = selectedAnnotations.has(i)}
+          {@const isAnnSelected = interaction.type === "marquee"
+            ? marqueeAnnotationCandidates.has(i)
+            : selectedAnnotations.has(i)}
           {@const annFontSize = 12 * (ann.scale ?? 1)}
-          {@const annLines = ann.text.split("\n")}
-          {@const annWidth = Math.max(...annLines.map((l) => l.length * 7.5 * (ann.scale ?? 1) + 14), 40)}
-          {@const annHeight = annLines.length * 16 * (ann.scale ?? 1) + 8}
-          {@const annX = ann.x - 4}
-          {@const annY = ann.y - 16 * (ann.scale ?? 1)}
+          {@const annHit = annotationHitBox(ann)}
+          {@const annX = annHit.x}
+          {@const annY = annHit.y}
+          {@const annWidth = annHit.width}
+          {@const annHeight = annHit.height}
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <g
             class="cursor-grab"

--- a/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
@@ -272,7 +272,6 @@ let visibleConnections = $derived(
   x={ann.x}
   y={ann.y}
   fill="var(--color-base-content)"
-  fill-opacity="0.7"
   font-size="12"
   text-anchor="start"
   style="pointer-events: none; user-select: none; white-space: pre"

--- a/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 import {
+  ANNOTATION_FONT_SIZE,
+  ANNOTATION_LINE_HEIGHT,
+  annotationLines,
   type Box,
   computeRenderOrder,
   computeVisibleConnections,
@@ -268,14 +271,19 @@ let visibleConnections = $derived(
 {/each}
 
 {#each annotations as ann (ann.text + ann.x + ann.y)}
+  {@const annScale = ann.scale ?? 1}
   <text
   x={ann.x}
   y={ann.y}
   fill="var(--color-base-content)"
-  font-size={12 * (ann.scale ?? 1)}
+  font-size={ANNOTATION_FONT_SIZE * annScale}
   text-anchor="start"
-  style="pointer-events: none; user-select: none; white-space: pre"
+  style="pointer-events: none; user-select: none"
 >
-    {ann.text}
+    {#each annotationLines(ann.text) as line, li (li)}
+      <tspan x={ann.x} dy={li === 0 ? 0 : ANNOTATION_LINE_HEIGHT * annScale}>
+        {line || '\u00a0'}
+      </tspan>
+    {/each}
   </text>
 {/each}

--- a/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
@@ -272,7 +272,7 @@ let visibleConnections = $derived(
   x={ann.x}
   y={ann.y}
   fill="var(--color-base-content)"
-  font-size="12"
+  font-size={12 * (ann.scale ?? 1)}
   text-anchor="start"
   style="pointer-events: none; user-select: none; white-space: pre"
 >

--- a/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramElements.svelte
@@ -16,6 +16,7 @@ import {
   selectionOutlineRect,
 } from "./visuals";
 import type {
+  DiagramStaticAnnotation,
   DiagramStaticBox,
   DiagramStaticComponent,
   DiagramStaticConnection,
@@ -25,6 +26,7 @@ let {
   components = [],
   connections = [],
   boxes = {},
+  annotations = [],
   markerId = "arrow",
   selected = new Set<number>(),
   linked = new Set<number>(),
@@ -34,6 +36,8 @@ let {
   components: DiagramStaticComponent[];
   connections: DiagramStaticConnection[];
   boxes: Record<number, DiagramStaticBox>;
+  /** View-level text annotations (absolute canvas positions). */
+  annotations?: DiagramStaticAnnotation[];
   markerId?: string;
   /** Component indices to show as selected (drawn with a transparent dotted outline on top). */
   selected?: Set<number>;
@@ -260,5 +264,19 @@ let visibleConnections = $derived(
   style="pointer-events: none; user-select: none"
 >
     {conn.label}
+  </text>
+{/each}
+
+{#each annotations as ann (ann.text + ann.x + ann.y)}
+  <text
+  x={ann.x}
+  y={ann.y}
+  fill="var(--color-base-content)"
+  fill-opacity="0.7"
+  font-size="12"
+  text-anchor="start"
+  style="pointer-events: none; user-select: none; white-space: pre"
+>
+    {ann.text}
   </text>
 {/each}

--- a/web/src/routes/projects/[id]/diagrams/DiagramEmbedView.stories.ts
+++ b/web/src/routes/projects/[id]/diagrams/DiagramEmbedView.stories.ts
@@ -75,6 +75,23 @@ export const Mobile: Story = {
   },
 };
 
+// Annotations far outside the node cluster: the zoom-to-fill bounds must
+// extend to cover them (and they must actually be rendered), mirroring
+// DiagramStaticView's fitted viewport behavior in the interactive embed.
+export const WithDistantAnnotations: Story = {
+  args: {
+    components: sampleComponents,
+    connections: sampleConnections,
+    boxes: sampleBoxes,
+    annotations: [
+      { text: "far above", x: 300, y: -400, scale: 2 },
+      { text: "far below", x: 300, y: 700 },
+    ],
+    projectId: "demo-project",
+    diagramPath: "overview.hcl",
+  },
+};
+
 // The embed view forwards an optional onnodehover callback to the rendered
 // nodes (used by the embed page to show the component docs popup). This story
 // verifies the callback fires with the hovered component index. The callback

--- a/web/src/routes/projects/[id]/diagrams/DiagramEmbedView.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramEmbedView.svelte
@@ -2,8 +2,9 @@
 import { resolve } from "$app/paths";
 import DiagramViewport from "./DiagramViewport.svelte";
 import DiagramElements from "./DiagramElements.svelte";
-import { unionBox } from "./geometry";
+import { annotationBounds, unionBox } from "./geometry";
 import type {
+  DiagramStaticAnnotation,
   DiagramStaticBox,
   DiagramStaticComponent,
   DiagramStaticConnection,
@@ -13,6 +14,7 @@ let {
   components = [],
   connections = [],
   boxes = {},
+  annotations = [],
   projectId = null,
   diagramPath = null,
   selected = new Set<number>(),
@@ -21,6 +23,7 @@ let {
   components: DiagramStaticComponent[];
   connections: DiagramStaticConnection[];
   boxes: Record<number, DiagramStaticBox>;
+  annotations?: DiagramStaticAnnotation[];
   projectId?: string | null;
   diagramPath?: string | null;
   /** Component indices to show as selected (drawn with a transparent dotted outline on top). */
@@ -33,8 +36,9 @@ let {
 
 let bounds = $derived.by(() => {
   const placed = Object.values(boxes);
-  if (placed.length === 0) return null;
-  return unionBox(placed);
+  const all = [...placed, ...annotations.map(annotationBounds)];
+  if (all.length === 0) return null;
+  return unionBox(all);
 });
 
 let fullDiagramUrl = $derived.by(() => {
@@ -52,6 +56,7 @@ let fullDiagramUrl = $derived.by(() => {
       {components}
       {connections}
       {boxes}
+      {annotations}
       markerId="embed-arrow"
       {selected}
       {onnodehover}

--- a/web/src/routes/projects/[id]/diagrams/DiagramStaticView.stories.ts
+++ b/web/src/routes/projects/[id]/diagrams/DiagramStaticView.stories.ts
@@ -107,3 +107,18 @@ export const Empty: Story = {
     boxes: {},
   },
 };
+
+// The pipeline with free-standing view annotations rendered at absolute
+// canvas positions — including a multi-line annotation (newline in text).
+export const WithAnnotations: Story = {
+  args: {
+    components: pipelineComponents,
+    connections: pipelineConnections,
+    boxes: pipelineBoxes,
+    annotations: [
+      { text: "Ingest path", x: 10, y: 10 },
+      { text: "Processed here\n(2 workers)", x: 230, y: 140 },
+      { text: "Note on queue", x: 200, y: 160 },
+    ],
+  },
+};

--- a/web/src/routes/projects/[id]/diagrams/DiagramStaticView.stories.ts
+++ b/web/src/routes/projects/[id]/diagrams/DiagramStaticView.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/svelte";
+import { expect, within } from "storybook/test";
 import DiagramStaticView from "./DiagramStaticView.svelte";
 import type {
   DiagramStaticBox,
@@ -110,6 +111,7 @@ export const Empty: Story = {
 
 // The pipeline with free-standing view annotations rendered at absolute
 // canvas positions — including a multi-line annotation (newline in text).
+// SVG collapses "\n" inside <text>, so each line must be its own <tspan>.
 export const WithAnnotations: Story = {
   args: {
     components: pipelineComponents,
@@ -120,6 +122,15 @@ export const WithAnnotations: Story = {
       { text: "Processed here\n(2 workers)", x: 230, y: 140 },
       { text: "Note on queue", x: 200, y: 160 },
     ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The multi-line annotation renders one <tspan> per line.
+    const firstLine = await canvas.findByText("Processed here");
+    const secondLine = await canvas.findByText("(2 workers)");
+    await expect(firstLine.tagName.toLowerCase()).toBe("tspan");
+    await expect(secondLine.tagName.toLowerCase()).toBe("tspan");
+    await expect(firstLine.parentElement).toBe(secondLine.parentElement);
   },
 };
 

--- a/web/src/routes/projects/[id]/diagrams/DiagramStaticView.stories.ts
+++ b/web/src/routes/projects/[id]/diagrams/DiagramStaticView.stories.ts
@@ -122,3 +122,29 @@ export const WithAnnotations: Story = {
     ],
   },
 };
+
+// The pipeline with an annotation placed far outside the node cluster's
+// bounding box and a scaled one — the auto-fit viewBox must extend to
+// include them, else the note would be clipped out of the Explore viewport.
+export const AnnotationsExtendTheFittedViewport: Story = {
+  args: {
+    components: pipelineComponents,
+    connections: pipelineConnections,
+    boxes: pipelineBoxes,
+    annotations: [
+      { text: "Distant note", x: 1200, y: -300, scale: 1.5 },
+      { text: "Below the cluster", x: 100, y: 900 },
+    ],
+  },
+};
+
+// Only annotations, no placed components — the viewBox must still fit them
+// (previously fell back to the fixed "0 0 100 100" default).
+export const AnnotationsOnly: Story = {
+  args: {
+    components: pipelineComponents,
+    connections: pipelineConnections,
+    boxes: {},
+    annotations: [{ text: "Just a note", x: 0, y: 0 }],
+  },
+};

--- a/web/src/routes/projects/[id]/diagrams/DiagramStaticView.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramStaticView.svelte
@@ -8,6 +8,7 @@
 import { unionBox } from "./geometry";
 import DiagramElements from "./DiagramElements.svelte";
 import type {
+  DiagramStaticAnnotation,
   DiagramStaticBox,
   DiagramStaticComponent,
   DiagramStaticConnection,
@@ -17,6 +18,7 @@ let {
   components = [],
   connections = [],
   boxes = {},
+  annotations = [],
   padding = 40,
   selected = new Set<number>(),
   linked = new Set<number>(),
@@ -28,6 +30,8 @@ let {
   connections: DiagramStaticConnection[];
   /** Which components are actually placed on the canvas, and where — keyed by index into `components`. A component with no entry here simply isn't rendered. */
   boxes: Record<number, DiagramStaticBox>;
+  /** View-level text annotations, rendered at absolute positions. */
+  annotations?: DiagramStaticAnnotation[];
   /** Empty space (world units) left around the content's bounding box in the auto-fit viewBox. */
   padding?: number;
   /** Component indices to show as selected (drawn with a transparent dotted outline on top). */
@@ -67,6 +71,7 @@ let viewBox = $derived.by(() => {
     {components}
     {connections}
     {boxes}
+    {annotations}
     {selected}
     {linked}
     {onnodeclick}

--- a/web/src/routes/projects/[id]/diagrams/DiagramStaticView.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramStaticView.svelte
@@ -5,7 +5,7 @@
 // canvas heavy to mount standalone: no drag/resize/marquee/pan/zoom
 // interaction, no undo history, no auto-layout, and critically, no
 // dependency on rhizz_wasm_wrapper/"rhizz" at all.
-import { unionBox } from "./geometry";
+import { annotationBounds, unionBox } from "./geometry";
 import DiagramElements from "./DiagramElements.svelte";
 import type {
   DiagramStaticAnnotation,
@@ -46,14 +46,16 @@ let {
     | undefined;
 } = $props();
 
-// Auto-fits the viewBox to whatever's actually placed, rather than
-// requiring a caller-managed pan/zoom state (there's no interaction here
-// to drive one) — makes this genuinely a one-prop-in, rendered-diagram-out
+// Auto-fits the viewBox to whatever's actually placed — including
+// annotations at far-away absolute positions — rather than requiring a
+// caller-managed pan/zoom state (there's no interaction here to drive
+// one) — makes this genuinely a one-prop-in, rendered-diagram-out
 // component, ideal for a Storybook thumbnail.
 let viewBox = $derived.by(() => {
   const placed = Object.values(boxes);
-  if (placed.length === 0) return "0 0 100 100";
-  const bounds = unionBox(placed);
+  const all = [...placed, ...annotations.map(annotationBounds)];
+  if (all.length === 0) return "0 0 100 100";
+  const bounds = unionBox(all);
   return `${bounds.x - padding} ${bounds.y - padding} ${
     bounds.width + padding * 2
   } ${bounds.height + padding * 2}`;

--- a/web/src/routes/projects/[id]/diagrams/DiagramToolbar.stories.ts
+++ b/web/src/routes/projects/[id]/diagrams/DiagramToolbar.stories.ts
@@ -24,6 +24,7 @@ const meta = {
     onresetview: () => {},
     onaddsystem: () => {},
     onaddcomponent: () => {},
+    onaddannotation: () => {},
   },
 } satisfies Meta<typeof DiagramToolbar>;
 
@@ -45,6 +46,14 @@ export const SnapActive: Story = {
 export const AutoLayoutRunning: Story = {
   args: {
     autoLayoutRunning: true,
+  },
+};
+
+// Exercises the "+ Note" annotation button alongside the system/component
+// buttons — the new annotation entry point.
+export const WithAnnotationButton: Story = {
+  args: {
+    onaddannotation: () => {},
   },
 };
 

--- a/web/src/routes/projects/[id]/diagrams/DiagramToolbar.svelte
+++ b/web/src/routes/projects/[id]/diagrams/DiagramToolbar.svelte
@@ -23,6 +23,7 @@ interface Props {
   onresetview: () => void;
   onaddsystem?: () => void;
   onaddcomponent?: () => void;
+  onaddannotation?: () => void;
 }
 
 let {
@@ -37,6 +38,7 @@ let {
   onresetview,
   onaddsystem,
   onaddcomponent,
+  onaddannotation,
 }: Props = $props();
 </script>
 
@@ -62,7 +64,7 @@ let {
       {/each}
     </select>
   </div>
-  {#if onaddsystem || onaddcomponent}
+  {#if onaddsystem || onaddcomponent || onaddannotation}
       {#if onaddsystem}
         <button
           onclick={onaddsystem}
@@ -79,6 +81,15 @@ let {
           title="Add a new component to the model"
         >
           + Component
+        </button>
+      {/if}
+      {#if onaddannotation}
+        <button
+          onclick={onaddannotation}
+          class="btn btn-ghost btn-sm"
+          title="Add a text annotation to the canvas"
+        >
+          + Note
         </button>
       {/if}
   {/if}

--- a/web/src/routes/projects/[id]/diagrams/embed/[...diagram]/+page.svelte
+++ b/web/src/routes/projects/[id]/diagrams/embed/[...diagram]/+page.svelte
@@ -137,9 +137,9 @@ function handleNodeHover(index: number | null, event?: MouseEvent) {
     <div class="flex-1 flex items-center justify-center text-sm text-base-content/60">
       Loading diagram…
     </div>
-  {:else if Object.keys(boxes).length === 0}
+  {:else if Object.keys(boxes).length === 0 && (layout.annotations ?? []).length === 0}
     <div class="flex-1 flex items-center justify-center text-sm text-base-content/60 p-4 text-center">
-      Diagram "{normalizedDiagramPath}" has no placed components.
+      Diagram "{normalizedDiagramPath}" has no placed components or annotations.
     </div>
   {:else}
     <div
@@ -150,6 +150,7 @@ function handleNodeHover(index: number | null, event?: MouseEvent) {
         components={components}
         connections={connections}
         boxes={boxes}
+        annotations={layout.annotations ?? []}
         projectId={projectId}
         diagramPath={normalizedDiagramPath}
         onnodehover={(index, event) => handleNodeHover(index, event)}

--- a/web/src/routes/projects/[id]/diagrams/geometry.test.ts
+++ b/web/src/routes/projects/[id]/diagrams/geometry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  annotationBounds,
   type Box,
   boxBoundaryPoint,
   boxCenter,
@@ -726,5 +727,48 @@ describe("computeLcaConnection", () => {
       "in",
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("annotationBounds", () => {
+  it("sizes a single-line annotation at default scale", () => {
+    // "XYZ" -> 3 chars * 7.5 + 14 = 36.5, clamped to the 40 minimum;
+    // one line -> 16 + 8 tall; anchored 4 left / 16 above (x, y).
+    const bounds = annotationBounds({ text: "XYZ", x: 10, y: 100 });
+    expect(bounds).toEqual({ x: 6, y: 84, width: 40, height: 24 });
+  });
+
+  it("grows with text length beyond the minimum width", () => {
+    // 16 chars * 7.5 + 14 = 134.
+    const bounds = annotationBounds({
+      text: "abcdefghijklmnop",
+      x: 0,
+      y: 0,
+    });
+    expect(bounds.width).toBe(134);
+  });
+
+  it("scales extents and offsets with scale", () => {
+    // "second" is the longest line: 6 chars * 7.5 * 2 + 14 = 104 wide;
+    // 2 lines * 16 * 2 + 8 = 72 tall; anchored 4 left / 16 * 2 = 32 above.
+    const bounds = annotationBounds({
+      text: "XYZ\nsecond",
+      x: 10,
+      y: 100,
+      scale: 2,
+    });
+    expect(bounds).toEqual({ x: 6, y: 68, width: 104, height: 72 });
+  });
+
+  it("treats missing scale as 1 (default)", () => {
+    const noScale = annotationBounds({ text: "note", x: 0, y: 0 });
+    const unitScale = annotationBounds({ text: "note", x: 0, y: 0, scale: 1 });
+    expect(noScale).toEqual(unitScale);
+  });
+
+  it("sizes multi-line text by its longest line and full line count", () => {
+    const bounds = annotationBounds({ text: "a\nb", x: 0, y: 0 });
+    expect(bounds.width).toBe(40); // single-char lines hit the minimum
+    expect(bounds.height).toBe(40); // 2 lines * 16 + 8
   });
 });

--- a/web/src/routes/projects/[id]/diagrams/geometry.test.ts
+++ b/web/src/routes/projects/[id]/diagrams/geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   annotationBounds,
+  annotationLines,
   type Box,
   boxBoundaryPoint,
   boxCenter,
@@ -727,6 +728,20 @@ describe("computeLcaConnection", () => {
       "in",
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("annotationLines", () => {
+  it("returns a single line when there is no newline", () => {
+    expect(annotationLines("note")).toEqual(["note"]);
+  });
+
+  it("splits on newlines, keeping empty lines", () => {
+    expect(annotationLines("a\n\nb")).toEqual(["a", "", "b"]);
+  });
+
+  it("keeps a trailing newline as an empty final line", () => {
+    expect(annotationLines("a\n")).toEqual(["a", ""]);
   });
 });
 

--- a/web/src/routes/projects/[id]/diagrams/geometry.ts
+++ b/web/src/routes/projects/[id]/diagrams/geometry.ts
@@ -28,6 +28,19 @@ export interface AnnotationLike {
   scale?: number;
 }
 
+// Base font size (px at 1x scale) and line step for view annotation text.
+// Shared by annotationBounds below and every SVG renderer so metrics,
+// hit-testing and the visible text can never drift apart.
+export const ANNOTATION_FONT_SIZE = 12;
+export const ANNOTATION_LINE_HEIGHT = 16;
+
+// Split annotation text into renderable lines. SVG <text> collapses "\n",
+// so renderers must emit one <tspan> per line returned here. Empty lines
+// (including a trailing newline) are kept so vertical rhythm is preserved.
+export function annotationLines(text: string): string[] {
+  return text.split("\n");
+}
+
 // Extent box of a view annotation's text, using the same geometry constants
 // as the interactive canvas's hit-testing (see annotationHitBox in
 // +page.svelte): ~7.5px per char at 1x scale, 16px line height, 14px
@@ -36,13 +49,18 @@ export interface AnnotationLike {
 // out of the fitted viewport.
 export function annotationBounds(ann: AnnotationLike): Box {
   const scale = ann.scale ?? 1;
-  const lines = ann.text.split("\n");
+  const lines = annotationLines(ann.text);
   const width = Math.max(
     ...lines.map((l) => l.length * 7.5 * scale + 14),
     40,
   );
-  const height = lines.length * 16 * scale + 8;
-  return { x: ann.x - 4, y: ann.y - 16 * scale, width, height };
+  const height = lines.length * ANNOTATION_LINE_HEIGHT * scale + 8;
+  return {
+    x: ann.x - 4,
+    y: ann.y - ANNOTATION_LINE_HEIGHT * scale,
+    width,
+    height,
+  };
 }
 
 // Identifies which edge or corner of a node is being dragged for resizing.

--- a/web/src/routes/projects/[id]/diagrams/geometry.ts
+++ b/web/src/routes/projects/[id]/diagrams/geometry.ts
@@ -19,6 +19,32 @@ export interface Box {
 export type ConnectionOrientation = "horizontal" | "vertical";
 export type ConnectionSide = "top" | "bottom" | "left" | "right";
 
+// A view annotation as stored in persisted layouts (the structural subset
+// both rhizz-wasm's Annotation and DiagramStaticAnnotation share).
+export interface AnnotationLike {
+  text: string;
+  x: number;
+  y: number;
+  scale?: number;
+}
+
+// Extent box of a view annotation's text, using the same geometry constants
+// as the interactive canvas's hit-testing (see annotationHitBox in
+// +page.svelte): ~7.5px per char at 1x scale, 16px line height, 14px
+// horizontal / 8px vertical padding, 40px minimum width. "Zoom to fill" and
+// the static renderers use this so a far-away annotation is never clipped
+// out of the fitted viewport.
+export function annotationBounds(ann: AnnotationLike): Box {
+  const scale = ann.scale ?? 1;
+  const lines = ann.text.split("\n");
+  const width = Math.max(
+    ...lines.map((l) => l.length * 7.5 * scale + 14),
+    40,
+  );
+  const height = lines.length * 16 * scale + 8;
+  return { x: ann.x - 4, y: ann.y - 16 * scale, width, height };
+}
+
 // Identifies which edge or corner of a node is being dragged for resizing.
 export type ResizeHandle =
   | "top"

--- a/web/src/routes/projects/[id]/diagrams/persistence.test.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.test.ts
@@ -11,6 +11,7 @@ import {
   emptyDiagramLayout,
   layoutToHcl,
   mapLayoutToBoxes,
+  parse_views,
   readDiagramLayoutFile,
   sanitizeStoredRecord,
   StoredBoxSchema,
@@ -187,6 +188,26 @@ describe("HCL View conversion and persistence", () => {
       height: 170,
       textAlign: "top-left",
     });
+  });
+
+  it("round-trips annotations through layoutToHcl and viewsToLayout", () => {
+    const layout = {
+      checked: {},
+      savedLayout: {},
+      annotations: [
+        { text: "First line\nSecond line", x: 12.5, y: -3 },
+        { text: "Standalone note", x: 0, y: 100 },
+      ],
+    };
+    const hcl = layoutToHcl(layout, "overview", "home");
+    expect(hcl).toContain("annotation {");
+    expect(hcl).toContain('text = "First line\\nSecond line"');
+
+    const back = parse_views(hcl)[0];
+    expect(back?.annotations).toEqual(layout.annotations);
+
+    const layout2 = viewsToLayout(back ? [back] : []);
+    expect(layout2.annotations).toEqual(layout.annotations);
   });
 
   it("returns an empty layout when the file has never been saved", async () => {

--- a/web/src/routes/projects/[id]/diagrams/persistence.test.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.test.ts
@@ -212,11 +212,35 @@ describe("HCL View conversion and persistence", () => {
     expect(layout2.annotations).toEqual(layout.annotations);
   });
 
-  it("returns an empty layout when the file has never been saved", async () => {
+  it("persists an annotation added after load, survives reload", async () => {
+    // Mimics the user repro: fresh project -> load (empty layout) -> add an
+    // annotation -> write -> reload -> annotation still there.
     const fs = await projectFs();
-    expect(await readDiagramLayoutFile(fs, MAIN_DIAGRAM_PATH)).toEqual(
+
+    // Fresh project starts with an empty (auto-seeded) diagram.
+    await writeDiagramLayoutFile(
+      fs,
+      MAIN_DIAGRAM_PATH,
       emptyDiagramLayout(),
+      "sys",
     );
+    const layout = await readDiagramLayoutFile(fs, MAIN_DIAGRAM_PATH);
+    expect(layout.annotations).toEqual([]);
+
+    const anns = layout.annotations ?? [];
+    // User adds an annotation (as addAnnotationHandler does) and edits text.
+    anns.push({ text: "New note", x: 10, y: 10 });
+    if (anns[0]) anns[0].text = "test";
+    await writeDiagramLayoutFile(fs, MAIN_DIAGRAM_PATH, layout, "sys");
+
+    // "Reload" (page switch) reads from the file again.
+    const reloaded = await readDiagramLayoutFile(fs, MAIN_DIAGRAM_PATH);
+    expect(reloaded.annotations).toEqual([
+      { text: "test", x: 10, y: 10 },
+    ]);
+    // And the raw file on disk has the annotation block.
+    const raw = await fs.readFile(MAIN_DIAGRAM_PATH);
+    expect(raw).toContain("annotation {");
   });
 
   it("round-trips a written layout to HCL and back", async () => {

--- a/web/src/routes/projects/[id]/diagrams/persistence.test.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.test.ts
@@ -195,18 +195,20 @@ describe("HCL View conversion and persistence", () => {
       checked: {},
       savedLayout: {},
       annotations: [
-        { text: "First line\nSecond line", x: 12.5, y: -3 },
+        { text: "First line\nSecond line", x: 12.5, y: -3, scale: 1.5 },
         { text: "Standalone note", x: 0, y: 100 },
       ],
     };
     const hcl = layoutToHcl(layout, "overview", "home");
     expect(hcl).toContain("annotation {");
-    expect(hcl).toContain('text = "First line\\nSecond line"');
+    // Non-default scale is persisted; the default (1) is not emitted.
+    expect(hcl).toContain("scale = 1.5");
+    expect(hcl).not.toMatch(/scale = 1\s/);
 
-    const back = parse_views(hcl)[0];
-    expect(back?.annotations).toEqual(layout.annotations);
-
-    const layout2 = viewsToLayout(back ? [back] : []);
+    // The real app path: parse -> viewsToLayout (which normalizes a serde-
+    // defaulted scale: 1 back to absent).
+    const back = parse_views(hcl);
+    const layout2 = viewsToLayout(back);
     expect(layout2.annotations).toEqual(layout.annotations);
   });
 

--- a/web/src/routes/projects/[id]/diagrams/persistence.test.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.test.ts
@@ -240,15 +240,21 @@ describe("HCL View conversion and persistence", () => {
           textAlign: "top-left" as const,
         },
       },
+      annotations: [
+        { text: "Persisted note", x: 30, y: 40, scale: 1.5 },
+      ],
     };
     await writeDiagramLayoutFile(fs, MAIN_DIAGRAM_PATH, layout, "sys");
 
     const content = await fs.readFile(MAIN_DIAGRAM_PATH);
     expect(content).toContain('view "main"');
     expect(content).toContain('node "sys/a"');
+    expect(content).toContain("annotation {");
+    expect(content).toContain("scale = 1.5");
 
     const read = await readDiagramLayoutFile(fs, MAIN_DIAGRAM_PATH);
     expect(read.checked["sys/a"]).toEqual(layout.checked["sys/a"]);
+    expect(read.annotations).toEqual(layout.annotations);
   });
 
   it("persists and reads connection startSide and endSide configuration", async () => {

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -291,20 +291,37 @@ export async function readDiagramLayoutFile(
     raw = await fs.readFile(path);
   } catch (error) {
     if (error instanceof VfsError && error.code === "ENOENT") {
+      console.log(`[PERSIST] read       ${path}: ENOENT -> empty layout (no file yet)`);
       return emptyDiagramLayout();
     }
     throw error;
   }
 
+  console.log(
+    `[PERSIST] read       ${path}: ${String(raw.length)} bytes ` +
+      `hasAnnotationBlock=${String(raw.includes("annotation {"))}`,
+  );
+
   try {
     const views = parse_views(raw);
     if (Array.isArray(views) && views.length > 0) {
-      return viewsToLayout(views);
+      const layout = viewsToLayout(views);
+      const parsedAnnotations = layout.annotations ?? [];
+      console.log(
+        `[PERSIST] parse      ${path}: ok views=${String(views.length)} ` +
+          `annotations=${String(parsedAnnotations.length)} ` +
+          `texts=${JSON.stringify(parsedAnnotations.map((a) => a.text))}`,
+      );
+      return layout;
     }
-  } catch {
-    // Malformed HCL content
+  } catch (err) {
+    console.error(
+      `[PERSIST] parse      ${path}: FAILED — falling back to EMPTY layout!`,
+      err,
+    );
   }
 
+  console.log(`[PERSIST] parse      ${path}: no usable views -> empty layout`);
   return emptyDiagramLayout();
 }
 
@@ -317,12 +334,23 @@ export async function writeDiagramLayoutFile(
   layout: DiagramLayout,
   systemName = "",
 ): Promise<void> {
+  console.log(
+    `[PERSIST] write      START ${path}: ` +
+      `checked=${String(Object.keys(layout.checked).length)} ` +
+      `annotations=${String(layout.annotations?.length ?? 0)} ` +
+      `texts=${JSON.stringify((layout.annotations ?? []).map((a) => a.text))}`,
+  );
   const lastSlash = path.lastIndexOf("/");
   const dir = lastSlash !== -1 ? path.slice(0, lastSlash) : DIAGRAM_LAYOUT_DIR;
   await fs.mkdir(dir, { recursive: true });
 
   const viewName = viewNameFromPath(path);
   const hclContent = layoutToHcl(layout, viewName, systemName);
+  const annotationBlocks = (hclContent.match(/annotation \{/g) ?? []).length;
+  console.log(
+    `[PERSIST] write      END ${path}: ${String(hclContent.length)} bytes ` +
+      `annotationBlocks=${String(annotationBlocks)}`,
+  );
   await fs.writeFile(path, hclContent);
 }
 

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -291,39 +291,20 @@ export async function readDiagramLayoutFile(
     raw = await fs.readFile(path);
   } catch (error) {
     if (error instanceof VfsError && error.code === "ENOENT") {
-      console.log(
-        `[PERSIST] read       ${path}: ENOENT -> empty layout (no file yet)`,
-      );
       return emptyDiagramLayout();
     }
     throw error;
   }
 
-  console.log(
-    `[PERSIST] read       ${path}: ${String(raw.length)} bytes ` +
-      `hasAnnotationBlock=${String(raw.includes("annotation {"))}`,
-  );
-
   try {
     const views = parse_views(raw);
     if (Array.isArray(views) && views.length > 0) {
-      const layout = viewsToLayout(views);
-      const parsedAnnotations = layout.annotations ?? [];
-      console.log(
-        `[PERSIST] parse      ${path}: ok views=${String(views.length)} ` +
-          `annotations=${String(parsedAnnotations.length)} ` +
-          `texts=${JSON.stringify(parsedAnnotations.map((a) => a.text))}`,
-      );
-      return layout;
+      return viewsToLayout(views);
     }
-  } catch (err) {
-    console.error(
-      `[PERSIST] parse      ${path}: FAILED — falling back to EMPTY layout!`,
-      err,
-    );
+  } catch {
+    // Malformed HCL content
   }
 
-  console.log(`[PERSIST] parse      ${path}: no usable views -> empty layout`);
   return emptyDiagramLayout();
 }
 
@@ -336,12 +317,6 @@ export async function writeDiagramLayoutFile(
   layout: DiagramLayout,
   systemName = "",
 ): Promise<void> {
-  console.log(
-    `[PERSIST] write      START ${path}: ` +
-      `checked=${String(Object.keys(layout.checked).length)} ` +
-      `annotations=${String(layout.annotations?.length ?? 0)} ` +
-      `texts=${JSON.stringify((layout.annotations ?? []).map((a) => a.text))}`,
-  );
   const lastSlash = path.lastIndexOf("/");
   const dir = lastSlash !== -1 ? path.slice(0, lastSlash) : DIAGRAM_LAYOUT_DIR;
   await fs.mkdir(dir, { recursive: true });
@@ -356,18 +331,12 @@ export async function writeDiagramLayoutFile(
   const layoutAnnotationCount = layout.annotations?.length ?? 0;
   if (layoutAnnotationCount > 0 && annotationBlocks === 0) {
     throw new Error(
-      `[PERSIST] DATALOSS-GUARD: ${
-        String(layoutAnnotationCount)
-      } annotation(s) in memory ` +
+      `[PERSIST] DATALOSS-GUARD: ${String(layoutAnnotationCount)} annotation(s) in memory ` +
         `but 0 serialized into ${path}. The compiled rhizz wasm pkg is STALE — ` +
         `rebuild it (wasm-pack build crates/rhizz-wasm --target web --release or ` +
         `\`just build\`), then restart the dev server and hard-refresh the browser.`,
     );
   }
-  console.log(
-    `[PERSIST] write      END ${path}: ${String(hclContent.length)} bytes ` +
-      `annotationBlocks=${String(annotationBlocks)}`,
-  );
   await fs.writeFile(path, hclContent);
 }
 

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -331,7 +331,9 @@ export async function writeDiagramLayoutFile(
   const layoutAnnotationCount = layout.annotations?.length ?? 0;
   if (layoutAnnotationCount > 0 && annotationBlocks === 0) {
     throw new Error(
-      `[PERSIST] DATALOSS-GUARD: ${String(layoutAnnotationCount)} annotation(s) in memory ` +
+      `[PERSIST] DATALOSS-GUARD: ${
+        String(layoutAnnotationCount)
+      } annotation(s) in memory ` +
         `but 0 serialized into ${path}. The compiled rhizz wasm pkg is STALE — ` +
         `rebuild it (wasm-pack build crates/rhizz-wasm --target web --release or ` +
         `\`just build\`), then restart the dev server and hard-refresh the browser.`,

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -347,6 +347,19 @@ export async function writeDiagramLayoutFile(
   const viewName = viewNameFromPath(path);
   const hclContent = layoutToHcl(layout, viewName, systemName);
   const annotationBlocks = (hclContent.match(/annotation \{/g) ?? []).length;
+  // Data-loss guard: if annotations exist in memory but the compiled wasm
+  // serializer emitted none, the wasm pkg (crates/rhizz-wasm/pkg, a gitignored
+  // build artifact) is stale and would silently erase annotations from disk.
+  // Abort the write loudly instead of overwriting the file.
+  const layoutAnnotationCount = layout.annotations?.length ?? 0;
+  if (layoutAnnotationCount > 0 && annotationBlocks === 0) {
+    throw new Error(
+      `[PERSIST] DATALOSS-GUARD: ${String(layoutAnnotationCount)} annotation(s) in memory ` +
+        `but 0 serialized into ${path}. The compiled rhizz wasm pkg is STALE — ` +
+        `rebuild it (wasm-pack build crates/rhizz-wasm --target web --release or ` +
+        `\`just build\`), then restart the dev server and hard-refresh the browser.`,
+    );
+  }
   console.log(
     `[PERSIST] write      END ${path}: ${String(hclContent.length)} bytes ` +
       `annotationBlocks=${String(annotationBlocks)}`,

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -266,7 +266,12 @@ export function viewsToLayout(views: ViewDefinition[]): DiagramLayout {
       }
     }
     for (const ann of view.annotations ?? []) {
-      annotations.push(ann);
+      // Normalize: scale 1 (the serde default for a missing scale) means the
+      // annotation is at the default 100%; drop it so it round-trips as
+      // absent, matching how layoutToHcl omits the default.
+      const normalized = { ...ann };
+      if (normalized.scale === 1) delete normalized.scale;
+      annotations.push(normalized);
     }
   }
 

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -6,6 +6,7 @@
 import { z } from "zod";
 import { type ProjectFs, VfsError } from "../../../../vfs/fs";
 import {
+  type Annotation,
   type ConnectionLayout,
   type NodeLayout,
   parse_views,
@@ -69,15 +70,17 @@ export function sanitizeStoredRecord(
 export const DIAGRAM_LAYOUT_DIR = "diagrams";
 
 // The full persisted content of a single diagram: which components are
-// currently placed on its canvas, every component's last-known box, and connection starting points.
+// currently placed on its canvas, every component's last-known box, connection
+// starting points, and free-standing text annotations.
 export interface DiagramLayout {
   checked: Record<string, StoredBox>;
   savedLayout: Record<string, StoredBox>;
   connections?: Record<string, StoredConnection>;
+  annotations?: Annotation[];
 }
 
 export function emptyDiagramLayout(): DiagramLayout {
-  return { checked: {}, savedLayout: {}, connections: {} };
+  return { checked: {}, savedLayout: {}, connections: {}, annotations: [] };
 }
 
 /**
@@ -215,6 +218,7 @@ export function layoutToHcl(
     },
     nodes,
     connections,
+    annotations: (layout.annotations ?? []).map((a) => ({ ...a })),
   };
 
   return serialize_views([viewDef]);
@@ -227,6 +231,7 @@ export function viewsToLayout(views: ViewDefinition[]): DiagramLayout {
   const checked: Record<string, StoredBox> = {};
   const savedLayout: Record<string, StoredBox> = {};
   const connections: Record<string, StoredConnection> = {};
+  const annotations: Annotation[] = [];
 
   for (const view of views) {
     for (const node of view.nodes ?? []) {
@@ -260,9 +265,12 @@ export function viewsToLayout(views: ViewDefinition[]): DiagramLayout {
         connections[conn.connection] = entry;
       }
     }
+    for (const ann of view.annotations ?? []) {
+      annotations.push(ann);
+    }
   }
 
-  return { checked, savedLayout, connections };
+  return { checked, savedLayout, connections, annotations };
 }
 
 /**
@@ -312,3 +320,6 @@ export async function writeDiagramLayoutFile(
   const hclContent = layoutToHcl(layout, viewName, systemName);
   await fs.writeFile(path, hclContent);
 }
+
+// Re-export so consumers/tests can parse canonical views HCL back.
+export { type Annotation, parse_views };

--- a/web/src/routes/projects/[id]/diagrams/persistence.ts
+++ b/web/src/routes/projects/[id]/diagrams/persistence.ts
@@ -291,7 +291,9 @@ export async function readDiagramLayoutFile(
     raw = await fs.readFile(path);
   } catch (error) {
     if (error instanceof VfsError && error.code === "ENOENT") {
-      console.log(`[PERSIST] read       ${path}: ENOENT -> empty layout (no file yet)`);
+      console.log(
+        `[PERSIST] read       ${path}: ENOENT -> empty layout (no file yet)`,
+      );
       return emptyDiagramLayout();
     }
     throw error;
@@ -354,7 +356,9 @@ export async function writeDiagramLayoutFile(
   const layoutAnnotationCount = layout.annotations?.length ?? 0;
   if (layoutAnnotationCount > 0 && annotationBlocks === 0) {
     throw new Error(
-      `[PERSIST] DATALOSS-GUARD: ${String(layoutAnnotationCount)} annotation(s) in memory ` +
+      `[PERSIST] DATALOSS-GUARD: ${
+        String(layoutAnnotationCount)
+      } annotation(s) in memory ` +
         `but 0 serialized into ${path}. The compiled rhizz wasm pkg is STALE — ` +
         `rebuild it (wasm-pack build crates/rhizz-wasm --target web --release or ` +
         `\`just build\`), then restart the dev server and hard-refresh the browser.`,

--- a/web/src/routes/projects/[id]/diagrams/types.ts
+++ b/web/src/routes/projects/[id]/diagrams/types.ts
@@ -20,3 +20,10 @@ export interface DiagramStaticConnection {
 
 /** A placed node's position/size/label alignment — `textAlign` defaults to "center" when omitted. */
 export type DiagramStaticBox = Box & { textAlign?: TextAlign };
+
+/** A view-level text annotation placed at an absolute canvas position. */
+export interface DiagramStaticAnnotation {
+  text: string;
+  x: number;
+  y: number;
+}

--- a/web/src/routes/projects/[id]/diagrams/types.ts
+++ b/web/src/routes/projects/[id]/diagrams/types.ts
@@ -26,4 +26,6 @@ export interface DiagramStaticAnnotation {
   text: string;
   x: number;
   y: number;
+  /** Font size multiplier; 1 = 100% (default). */
+  scale?: number;
 }

--- a/web/src/routes/projects/[id]/explore/Explore.svelte
+++ b/web/src/routes/projects/[id]/explore/Explore.svelte
@@ -425,6 +425,7 @@ let boxes = $derived.by<Record<number, DiagramStaticBox>>(() => {
               components={components}
               connections={connections}
               boxes={boxes}
+              annotations={selectedLayout.annotations ?? []}
               linked={linkedComponents}
               onnodeclick={handleNodeClick}
               onnodehover={(index, event) => handleNodeHover(index, event)}


### PR DESCRIPTION
Annotations are free-standing text markers on a view canvas, stored in views.hcl (never the system model) at absolute positions, plain text with multi-line support. Deliberately no node anchoring, per the task decision.

- rhizz-core: Annotation {text,x,y} on ViewDefinition; serializer emits 'annotation { x y text }' blocks inside view blocks (sorted by text); parser reads them; round-trip test; export from lib. ViewDefinition initializers updated (from_resolved, parse_views, proptest).
- rhizz-wasm: flows through the existing serde path (no binding change).
- web: Annotation type in wasm wrapper; DiagramLayout.annotations through layoutToHcl/viewsToLayout + DocumentStore; +page reads/writes state; DiagramElements renders labels (incl. multi-line via white-space: pre); DiagramStaticView passes them through; Storybook WithAnnotations story.
- Tests: rhizz-core annotation round-trip; web persistence round-trip (layoutToHcl -> parse_views -> viewsToLayout). 16 Rust suites + 475 web tests, clippy/eslint/svelte-check clean.